### PR TITLE
Optionally run node.js in docker to avoid installing in on host machine

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+*.iml
+.DS_Store
+node_modules
+dist
+types
+*.local
+/mobile/
+.idea
+*~
+
+
+.git/
+.gitignore
+Dockerfile
+docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ types
 /mobile/www/
 !/mobile/www/.dirkeep
 .idea
+*~

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:14 as base
+#ENV NODE_ENV=production
+
+WORKDIR /app
+ENV PATH /app/node_modules/.bin:${PATH}
+
+COPY ["package.json", "package-lock.json*", "./"]
+
+RUN npm install
+
+
+
+FROM base as build
+
+COPY . .
+
+RUN npm run build

--- a/README.md
+++ b/README.md
@@ -15,6 +15,25 @@ Run vite (we're obviously using vitejs for vite-ma-dose !) :
 Open your browser : http://localhost:3000/
 and enjoy live reload / on-the-fly typescript compilation
 
+# Run with docker
+If you don't want to install node.js on your machine, you can isolate it with [docker](https://www.docker.com/get-started):
+
+Start docker container (that executes `npm run dev`) :
+`docker-compose up`
+
+## Docker how-to
+The first time `docker-compose up` is run, it will build the `base` docker image with `npm install` inside `node:14` docker image.
+
+When the `package*.json` have changed, you need to rebuild the base image:
+```
+docker-compose down --volumes
+docker-compose build
+```
+.. then start again with `docker-compose up`.
+
+
+To inspect what happens inside : `docker-compose exec frontend bash`
+
 # Production
 
 Package for production with `vite build` : `dist` directory will contain minified assets for production
@@ -29,14 +48,14 @@ See [dedicated readme in `mobile/` directory](mobile/README.md)
 # Development workflow
 
 - `main` is automatically deployed on https://vitemadose.covidtracker.fr/
-  
+
   => Push on this branch only when you're ready.
 
 - `dev` is the development branch, start any new feature/fix from it.
-  
+
   We generally try to create dedicated feature branches with issue number in it, except when the
   commit is really small
-  
+
 # Stack pointers
 
 We're using :

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Run vite (we're obviously using vitejs for vite-ma-dose !) :
 Open your browser : http://localhost:3000/
 and enjoy live reload / on-the-fly typescript compilation
 
-# Run with docker
+## Alternative: Running with docker
 If you don't want to install node.js on your machine, you can isolate it with [docker](https://www.docker.com/get-started):
 
 Start docker container (that executes `npm run dev`) :
 `docker-compose up`
 
-## Docker how-to
+### Docker how-to
 The first time `docker-compose up` is run, it will build the `base` docker image with `npm install` inside `node:14` docker image.
 
 When the `package*.json` have changed, you need to rebuild the base image:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+
+services:
+  frontend:
+    build:
+      context: .
+      target: base
+    volumes:
+      - .:/app
+      - node_modules:/app/node_modules
+    working_dir: /app
+    command: npm run dev
+    #command: sleep infinity
+    ports:
+      - 3000:3000
+
+volumes:
+  node_modules:


### PR DESCRIPTION
J'ai pour habitude de travailler depuis docker; si ça peut aider d'autres gens je propose cette PR.

- `npm install` is executed during docker build
- mounting sources into the container hides the pre-built
  `node_modules/`, so we use a volume that is automatically populated by
  the files already present in the docker image volume mount point:
  the pre-build `node_modules/`
  - pros: it avoids permissions issues: no file is written as root on
    host.
  - cons: it requires volume deletion on base image rebuild
- will require maintaining `.dockerignore` in parallel to `.gitignore`