### PR TITLE
Improve accessibility in appointment list

### DIFF
--- a/src/components/vmd-appointment-card.component.ts
+++ b/src/components/vmd-appointment-card.component.ts
@@ -69,9 +69,9 @@ export class VmdAppointmentCardComponent extends LitElement {
 
                         ${this.estCliquable?html`
                         <div class="col-24 col-md-auto text-center mt-4 mt-md-0">
-                            <a target="_blank" class="btn btn-primary btn-lg">
+                            <button class="btn btn-primary btn-lg">
                               Prendre rendez-vous
-                            </a>
+                            </button>
                             <div class="row align-items-center justify-content-center mt-3 text-black-50">
                                 <div class="col-auto">
                                   ${this.lieu.appointment_count.toLocaleString()} dose${Strings.plural(this.lieu.appointment_count)}


### PR DESCRIPTION
Actuellement il n'est pas possible de naviguer au clavier pour accéder aux liens pour prendre des rendez-vous. 

En utilisant l'attribut `href` c'est désormais possible ce qui améliore l'accessibilité.