### PR TITLE
Déploiement automatisé de toutes les branches

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -19,7 +19,7 @@ jobs:
       - run: npm ci
       - run: npm run build
         env:
-          BASE_URL:  "/${{ env.GITHUB_REF_SLUG }}"
+          BASE_URL:  "${{ env.GITHUB_REF_SLUG }}/"
       - name: rsync deployments
         uses: burnett01/rsync-deployments@4.1
         with:

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -1,0 +1,31 @@
+name: Déploiement Vite ma dose (branches)
+
+on:
+  push:
+    branches:
+      - nicolas
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v3.x
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "14.12"
+      - run: npm ci
+      - run: npm run build
+        env:
+          BASE_URL:  "/"
+      - name: rsync deployments
+        uses: burnett01/rsync-deployments@4.1
+        with:
+          switches: -avz --delete --exclude ".git*"
+          path: ./dist/
+          remote_path: ${{ secrets.DEPLOY_PATH_DEV }}${{ env.GITHUB_REF_SLUG }}
+          remote_host: ${{ secrets.DEPLOY_IP }}
+          remote_user: ubuntu
+          remote_key: ${{ secrets.DEPLOY_KEY }}

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -17,13 +17,7 @@ jobs:
         with:
           node-version: "14.12"
       - run: npm ci
-      - run: npm run build
-        env:
-          BASE_URL:  "${{ env.GITHUB_REF_SLUG }}/"
-      - run: echo $BASE_URL > ./dist/test1.txt
-        env:
-          BASE_URL:  "${{ env.GITHUB_REF_SLUG }}/"
-      - run: echo "${{ env.GITHUB_REF_SLUG }}/" > ./dist/test2.txt
+      - run: npm run build -- --base "${{ env.GITHUB_REF_SLUG }}/"
       - name: rsync deployments
         uses: burnett01/rsync-deployments@4.1
         with:

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -20,6 +20,10 @@ jobs:
       - run: npm run build
         env:
           BASE_URL:  "${{ env.GITHUB_REF_SLUG }}/"
+      - run: echo $BASE_URL > ./dist/test1.txt
+        env:
+          BASE_URL:  "${{ env.GITHUB_REF_SLUG }}/"
+      - run: echo "${{ env.GITHUB_REF_SLUG }}/" > ./dist/test2.txt
       - name: rsync deployments
         uses: burnett01/rsync-deployments@4.1
         with:

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -19,7 +19,7 @@ jobs:
       - run: npm ci
       - run: npm run build
         env:
-          BASE_URL:  "/"
+          BASE_URL:  "/${{ env.GITHUB_REF_SLUG }}"
       - name: rsync deployments
         uses: burnett01/rsync-deployments@4.1
         with:

--- a/index.html
+++ b/index.html
@@ -162,3 +162,4 @@
     </div>
 </body>
 </html>
+<!-- test -->

--- a/index.html
+++ b/index.html
@@ -162,4 +162,4 @@
     </div>
 </body>
 </html>
-<!-- test -->
+<!-- test 2 -->

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite --base nicolas/ build"
+    "build": "tsc && vite --base ${BASE_PATH:-/} build"
   },
   "devDependencies": {
     "@types/leaflet": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite --base ${BASE_PATH:-/} build"
+    "build": "tsc && vite build"
   },
   "devDependencies": {
     "@types/leaflet": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite --base ${BASE_PATH:-/} build"
+    "build": "tsc && vite --base nicolas/ build"
   },
   "devDependencies": {
     "@types/leaflet": "1.7.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import autoprefixer = require('autoprefixer')
 // https://vitejs.dev/config/
 export default ({ command, mode }) => ({
   build: {
-    sourcemap: false
+    sourcemap: true
   },
   css: {
     postcss: {


### PR DESCRIPTION
J’ouvre la PR, mais ça n’est pas encore au point. J’ai bien un site web pour une branche, exemple avec celle que j’ai créée pour tester : https://dev.vitemado.se/nicolas/

Mais il ne charge que le HTML, ni JS, ni CSS. Les appels aux assets sont en relatif pourtant et j’ai vérifié, tous les fichiers sont bien présents sur le serveur.

Du coup, je sèche un peu. Si quelqu’un veut reprendre, il faudra modifier la condition en tête de l’action (pour le moment j’ai mis uniquement sur ma branche de test, il faudra mettre sur toutes les branches sauf main).

Pour récupérer le nom de la branche, j’ai utilisé cette action clé en main : https://github.com/marketplace/actions/github-slug-action 

Le nom de la branche est disponible avec la variable `${{ env.GITHUB_REF_SLUG }}`. 