### PR TITLE
#41 Afficher message si refresh inférieur à 1 minute

### DIFF
--- a/src/utils/Dates.ts
+++ b/src/utils/Dates.ts
@@ -91,7 +91,9 @@ export class Dates {
     }
 
     public static formatDuration(durationFromNow: Duration): string {
-        if(durationFromNow.totalHours === 0) {
+        if (durationFromNow.totalMinutes === 0) {
+            return 'quelques instants';
+        } else if(durationFromNow.totalHours === 0) {
             return `${Dates.showValue(durationFromNow.minutes, ' minute')}`;
         } else if(durationFromNow.totalHours <= 6) {
             return `${Dates.showValue(durationFromNow.hours, ' heure')} ${Dates.showValue(durationFromNow.minutes, ' minute')}`;


### PR DESCRIPTION
Fix #41 

Dans le cas où le raffraîchissement a été fait il y a moins d'une minute.

Affichage du message :
> Dernière mise à jour : il y a quelques instants

![image](https://user-images.githubusercontent.com/15015617/114467681-92a6f580-9bea-11eb-9da0-d0f897a9604b.png)
