### PR TITLE
#75 retirer les balises <a href=""> vides sur chacun des logos

### DIFF
--- a/src/views/vmd-home.view.ts
+++ b/src/views/vmd-home.view.ts
@@ -107,7 +107,7 @@ export class VmdHomeView extends LitElement {
                   ${Object.values(PLATEFORMES).filter(p => p.promoted).map(plateforme => {
                       return html`
                         <div class="col-auto">
-                          <a href=""><img class="searchAppointment-logo ${plateforme.styleCode}" src="${Router.basePath}assets/images/png/${plateforme.logo}" alt="Créneaux de vaccination ${plateforme.nom}"></a>
+                          <img class="searchAppointment-logo ${plateforme.styleCode}" src="${Router.basePath}assets/images/png/${plateforme.logo}" alt="Créneaux de vaccination ${plateforme.nom}"></a>
                         </div>
                       `
                   })}


### PR DESCRIPTION
**Fix #75** 

bonjour, première fois que je participe à un projet donc si je fais mal certaines choses merci de me le dire :) 

J'ai enlevé les balises `<a href="">` vides des logos dans le fichier "[src/views/vmd-home.view.ts]("https://github.com/CovidTrackerFr/vitemadose-front/blob/dev/src/views/vmd-home.view.ts")"