### PR TITLE
fixes #92 Doc: Recommend usage of 'npm ci'

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Don't hesitate to install multiple `node` version in your dev environment using 
 # Boostrap
 
 Install dependencies :
-`npm install`
+`npm ci`
 
 Run vite (we're obviously using vitejs for vite-ma-dose !) :
 `npm run dev` or `vite` (see `package.json` scripts)


### PR DESCRIPTION
fixes #92

Recommande l'utilisation de `npm ci` pour le déploiement du projet, voir justification sur #92 