### PR TITLE
Fixes #89, prevent dev CI on forks

### DIFF
--- a/.github/workflows/deploy-branches-and-prs.yml
+++ b/.github/workflows/deploy-branches-and-prs.yml
@@ -11,6 +11,11 @@ on:
 
 jobs:
   deploy-dev:
+    # This workflow is only of value to the CovidTrackerFr/vitemadose-front repository and
+    # would always fail in forks, so we limit this job to CovidTrackerFr/vitemadose-front
+    # See : https://github.com/CovidTrackerFr/vitemadose-front/issues/89
+    if: ${{ github.event.pull_request.head.repo.full_name == 'CovidTrackerFr/vitemadose-front' }}
+
     runs-on: ubuntu-latest
     steps:
       - name: Inject slug/short variables

--- a/.github/workflows/deploy-branches-and-prs.yml
+++ b/.github/workflows/deploy-branches-and-prs.yml
@@ -13,8 +13,11 @@ jobs:
   deploy-dev:
     # This workflow is only of value to the CovidTrackerFr/vitemadose-front repository and
     # would always fail in forks, so we limit this job to CovidTrackerFr/vitemadose-front
+    # It means, 2 different cases when we want to run this job :
+    # - 'push' events (as it comes from the repository itself)
+    # - 'pull_requests' comming from the base repository
     # See : https://github.com/CovidTrackerFr/vitemadose-front/issues/89
-    if: ${{ github.event.pull_request.head.repo.full_name == 'CovidTrackerFr/vitemadose-front' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'CovidTrackerFr/vitemadose-front' }}
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
_Fixes : #89_ 

Tentative de configuration qui devrait empêcher l'exécution du job de déploiement/CI de DEV sur les PRs provenant de forks.

A priori on ne peut pas limiter de manière "plus propre", je ne suis pas expert dans le domaine mais je pense que ça devrait répondre au besoin.

Basé sur : https://github.community/t/stop-github-actions-running-on-a-fork/17965/2 

