### PR TITLE
#94 optim refresh lieux

### DIFF
--- a/src/state/State.ts
+++ b/src/state/State.ts
@@ -179,12 +179,14 @@ export class State {
         } else {
             const resp = await fetch(`${VMD_BASE_URL}/${codeDepartement}.json`)
             const results = await resp.json()
-            return {
+            const lieuxParDepartement = {
                 lieuxDisponibles: results.centres_disponibles.map(transformLieu),
                 lieuxIndisponibles: results.centres_indisponibles.map(transformLieu),
                 codeDepartements: [codeDepartement],
                 derniereMiseAJour: results.last_updated
             };
+            this._lieuxParDepartement.set(codeDepartement, lieuxParDepartement);
+            return lieuxParDepartement;
         }
     }
 

--- a/src/views/vmd-rdv.view.ts
+++ b/src/views/vmd-rdv.view.ts
@@ -381,25 +381,31 @@ export class VmdRdvParCommuneView extends AbstractVmdRdvView {
 
     async onCommuneAutocompleteLoaded(autocompletes: string[]): Promise<string[]> {
         if(this.codePostalSelectionne && this.codeCommuneSelectionne) {
-            const autocompletesSet = new Set(autocompletes);
-            const autoCompleteCodePostal = this.codePostalSelectionne.split('')
-                .map((_, index) => this.codePostalSelectionne!.substring(0, index+1))
-                .find(autoCompleteAttempt => autocompletesSet.has(autoCompleteAttempt));
+            let codePostalSelectionne = this.codePostalSelectionne;
+            return await this.refreshBasedOnCodePostalSelectionne(autocompletes, codePostalSelectionne);
+        } else {
+            await this.refreshLieux();
+            return autocompletes;
+        }
+    }
 
-            if(!autoCompleteCodePostal) {
-                console.error(`Can't find autocomplete matching codepostal ${this.codePostalSelectionne}`);
-                return autocompletes;
-            }
+    private async refreshBasedOnCodePostalSelectionne(autocompletes: string[], codePostalSelectionne: string) {
+        const autocompletesSet = new Set(autocompletes);
+        const autoCompleteCodePostal = codePostalSelectionne.split('')
+            .map((_, index) => codePostalSelectionne!.substring(0, index + 1))
+            .find(autoCompleteAttempt => autocompletesSet.has(autoCompleteAttempt));
 
-            await this.updateCommunesDisponiblesBasedOnAutocomplete(autoCompleteCodePostal);
+        if (!autoCompleteCodePostal) {
+            console.error(`Can't find autocomplete matching codepostal ${codePostalSelectionne}`);
+            return autocompletes;
+        }
 
-            const communeSelectionnee = this.getCommuneSelectionnee();
-            if (communeSelectionnee) {
-                this.fillCommuneInSelector(communeSelectionnee, autoCompleteCodePostal);
-                await this.communeSelected(communeSelectionnee, false);
-            } else {
-                await this.refreshLieux();
-            }
+        await this.updateCommunesDisponiblesBasedOnAutocomplete(autoCompleteCodePostal);
+
+        const communeSelectionnee = this.getCommuneSelectionnee();
+        if (communeSelectionnee) {
+            this.fillCommuneInSelector(communeSelectionnee, autoCompleteCodePostal);
+            await this.communeSelected(communeSelectionnee, false);
         } else {
             await this.refreshLieux();
         }

--- a/src/views/vmd-rdv.view.ts
+++ b/src/views/vmd-rdv.view.ts
@@ -391,15 +391,11 @@ export class VmdRdvParCommuneView extends AbstractVmdRdvView {
                 return autocompletes;
             }
 
-            this.recuperationCommunesEnCours = true;
-            this.communesDisponibles = await State.current.communesPourAutocomplete(Router.basePath, autoCompleteCodePostal)
-            this.recuperationCommunesEnCours = false;
+            await this.updateCommunesDisponiblesBasedOnAutocomplete(autoCompleteCodePostal);
 
             const communeSelectionnee = this.getCommuneSelectionnee();
             if (communeSelectionnee) {
-                const component = (this.shadowRoot!.querySelector("vmd-commune-or-departement-selector") as VmdCommuneSelectorComponent)
-                component.fillCommune(communeSelectionnee, autoCompleteCodePostal);
-
+                this.fillCommuneInSelector(communeSelectionnee, autoCompleteCodePostal);
                 await this.communeSelected(communeSelectionnee, false);
             } else {
                 await this.refreshLieux();
@@ -409,6 +405,17 @@ export class VmdRdvParCommuneView extends AbstractVmdRdvView {
         }
 
         return autocompletes;
+    }
+
+    private async updateCommunesDisponiblesBasedOnAutocomplete(autoCompleteCodePostal: string) {
+        this.recuperationCommunesEnCours = true;
+        this.communesDisponibles = await State.current.communesPourAutocomplete(Router.basePath, autoCompleteCodePostal)
+        this.recuperationCommunesEnCours = false;
+    }
+
+    private fillCommuneInSelector(communeSelectionnee: Commune, autoCompleteCodePostal: string) {
+        const component = (this.shadowRoot!.querySelector("vmd-commune-or-departement-selector") as VmdCommuneSelectorComponent)
+        component.fillCommune(communeSelectionnee, autoCompleteCodePostal);
     }
 
     protected getCommuneSelectionnee(): Commune|undefined {

--- a/src/views/vmd-rdv.view.ts
+++ b/src/views/vmd-rdv.view.ts
@@ -235,8 +235,8 @@ export abstract class AbstractVmdRdvView extends LitElement {
         `;
     }
 
-    onCommuneAutocompleteLoaded(autocompletes: string[]): Promise<string[]> {
-        return Promise.resolve(autocompletes);
+    onCommuneAutocompleteLoaded(autocompletes: string[]): Promise<void> {
+        return Promise.resolve();
     }
 
     onceStartupPromiseResolved() {
@@ -250,9 +250,8 @@ export abstract class AbstractVmdRdvView extends LitElement {
             State.current.departementsDisponibles().then(departementsDisponibles => {
                 this.departementsDisponibles = departementsDisponibles;
             }),
-            State.current.communeAutocompleteTriggers(Router.basePath).then((autocompletes) => {
-                return this.onCommuneAutocompleteLoaded(autocompletes);
-            }).then(autocompletes => {
+            State.current.communeAutocompleteTriggers(Router.basePath).then(async (autocompletes) => {
+                await this.onCommuneAutocompleteLoaded(autocompletes);
                 this.communesAutocomplete = new Set(autocompletes);
             })
         ])
@@ -379,13 +378,12 @@ export class VmdRdvParCommuneView extends AbstractVmdRdvView {
         `
     }
 
-    async onCommuneAutocompleteLoaded(autocompletes: string[]): Promise<string[]> {
+    async onCommuneAutocompleteLoaded(autocompletes: string[]): Promise<void> {
         if(this.codePostalSelectionne && this.codeCommuneSelectionne) {
             let codePostalSelectionne = this.codePostalSelectionne;
-            return await this.refreshBasedOnCodePostalSelectionne(autocompletes, codePostalSelectionne);
+            await this.refreshBasedOnCodePostalSelectionne(autocompletes, codePostalSelectionne);
         } else {
             await this.refreshLieux();
-            return autocompletes;
         }
     }
 

--- a/src/views/vmd-rdv.view.ts
+++ b/src/views/vmd-rdv.view.ts
@@ -401,10 +401,12 @@ export class VmdRdvParCommuneView extends AbstractVmdRdvView {
                 component.fillCommune(communeSelectionnee, autoCompleteCodePostal);
 
                 await this.communeSelected(communeSelectionnee, false);
+            } else {
+                await this.refreshLieux();
             }
+        } else {
+            await this.refreshLieux();
         }
-
-        await this.refreshLieux();
 
         return autocompletes;
     }

--- a/src/views/vmd-rdv.view.ts
+++ b/src/views/vmd-rdv.view.ts
@@ -390,11 +390,7 @@ export class VmdRdvParCommuneView extends AbstractVmdRdvView {
     }
 
     private async refreshBasedOnCodePostalSelectionne(autocompletes: string[], codePostalSelectionne: string) {
-        const autocompletesSet = new Set(autocompletes);
-        const autoCompleteCodePostal = codePostalSelectionne.split('')
-            .map((_, index) => codePostalSelectionne!.substring(0, index + 1))
-            .find(autoCompleteAttempt => autocompletesSet.has(autoCompleteAttempt));
-
+        const autoCompleteCodePostal = this.getAutoCompleteCodePostal(autocompletes, codePostalSelectionne);
         if (!autoCompleteCodePostal) {
             console.error(`Can't find autocomplete matching codepostal ${codePostalSelectionne}`);
             return autocompletes;
@@ -411,6 +407,13 @@ export class VmdRdvParCommuneView extends AbstractVmdRdvView {
         }
 
         return autocompletes;
+    }
+
+    private getAutoCompleteCodePostal(autocompletes: string[], codePostalSelectionne: string) {
+        const autocompletesSet = new Set(autocompletes);
+        return codePostalSelectionne.split('')
+            .map((_, index) => codePostalSelectionne!.substring(0, index + 1))
+            .find(autoCompleteAttempt => autocompletesSet.has(autoCompleteAttempt));
     }
 
     private async updateCommunesDisponiblesBasedOnAutocomplete(autoCompleteCodePostal: string) {

--- a/src/views/vmd-rdv.view.ts
+++ b/src/views/vmd-rdv.view.ts
@@ -134,8 +134,6 @@ export abstract class AbstractVmdRdvView extends LitElement {
             }
         }
 
-        await this.refreshLieux();
-
         return Promise.resolve();
     }
 
@@ -151,8 +149,6 @@ export abstract class AbstractVmdRdvView extends LitElement {
             if(triggerNavigation) {
                 this.refreshPageWhenValidParams();
             }
-
-            await this.refreshLieux();
         }
 
         return Promise.resolve();
@@ -256,7 +252,8 @@ export abstract class AbstractVmdRdvView extends LitElement {
             })
         ])
 
-        this.onceStartupPromiseResolved();
+        await this.onceStartupPromiseResolved();
+        await this.refreshLieux();
     }
 
     preventRafraichissementLieux(): boolean {
@@ -382,8 +379,6 @@ export class VmdRdvParCommuneView extends AbstractVmdRdvView {
         if(this.codePostalSelectionne && this.codeCommuneSelectionne) {
             let codePostalSelectionne = this.codePostalSelectionne;
             await this.refreshBasedOnCodePostalSelectionne(autocompletes, codePostalSelectionne);
-        } else {
-            await this.refreshLieux();
         }
     }
 
@@ -400,8 +395,6 @@ export class VmdRdvParCommuneView extends AbstractVmdRdvView {
         if (communeSelectionnee) {
             this.fillCommuneInSelector(communeSelectionnee, autoCompleteCodePostal);
             await this.communeSelected(communeSelectionnee, false);
-        } else {
-            await this.refreshLieux();
         }
 
         return autocompletes;
@@ -514,8 +507,6 @@ export class VmdRdvParDepartementView extends AbstractVmdRdvView {
                 await this.departementSelected(departementSelectionne, false);
             }
         }
-
-        await this.refreshLieux();
     }
 
     libelleLieuSelectionne(): TemplateResult {


### PR DESCRIPTION
Fix #94 

\+ Décomposition de `onCommuneAutocompleteLoaded()` en plusieurs méthodes pour isoler les différents traitements.