### PR TITLE
Improve the appointment list

### DIFF
--- a/src/components/vmd-appointment-card.component.scss
+++ b/src/components/vmd-appointment-card.component.scss
@@ -42,6 +42,12 @@
       background-color: darken($card-bg, 3%);
     }
 
+    &.bg-disabled {
+      &:hover {
+        background-color: darken($gray-400, 3%);
+      }
+    }
+
     cursor: pointer;
   }
 

--- a/src/components/vmd-appointment-card.component.ts
+++ b/src/components/vmd-appointment-card.component.ts
@@ -90,9 +90,9 @@ export class VmdAppointmentCardComponent extends LitElement {
 
                         ${this.estCliquable?html`
                         <div class="col-24 col-md-auto text-center mt-4 mt-md-0">
-                            <a href="${this.lieu.url}" class="btn btn-primary btn-lg">
+                            <span tabindex="0" role="link" data-href="${this.lieu.url}" class="btn btn-primary btn-lg">
                               Prendre rendez-vous
-                            </a>
+                            </span>
                             <div class="row align-items-center justify-content-center mt-3 text-black-50">
                                 <div class="col-auto">
                                   ${this.lieu.appointment_count.toLocaleString()} dose${Strings.plural(this.lieu.appointment_count)}
@@ -134,7 +134,7 @@ export class VmdAppointmentCardComponent extends LitElement {
 
                     ${this.estCliquable?html`
                     <div class="col-24 col-md-auto text-center mt-4 mt-md-0">
-                      <a href="${this.lieu.url}" class="btn btn-info btn-lg">Vérifier le centre de vaccination</a>
+                      <span tabindex="0" role="link" data-href="${this.lieu.url}" class="btn btn-info btn-lg">Vérifier le centre de vaccination</span>
                     </div>
                     `:html``}
                   </div>

--- a/src/components/vmd-appointment-card.component.ts
+++ b/src/components/vmd-appointment-card.component.ts
@@ -56,8 +56,9 @@ export class VmdAppointmentCardComponent extends LitElement {
               distance = distance.toFixed(1)
             }
             return html`
-            <div class="card rounded-3 mb-5 p-4 ${classMap({clickable: this.estCliquable})}" title="${this.estCliquable ? this.lieu.url : ''}"
-                 @click="${() => this.prendreRdv()}">
+            <div class="card rounded-3 mb-5 p-4 ${classMap({clickable: this.estCliquable})}"
+              title="${this.estCliquable ? this.lieu.url : ''}"
+              @click="${() => this.prendreRdv()}">
                 <div class="card-body">
                     <div class="row align-items-center ">
                         <div class="col">

--- a/src/components/vmd-appointment-card.component.ts
+++ b/src/components/vmd-appointment-card.component.ts
@@ -46,6 +46,20 @@ export class VmdAppointmentCardComponent extends LitElement {
         }));
     }
 
+    makeEnterAsClick(event: Event, type: String) {
+        if (event.key !== 'Enter') {
+            return;
+        }
+        switch (type) {
+            case 'prendreRdv':
+                return this.prendreRdv();
+            case 'verifierRdv':
+                return this.verifierRdv();
+            default:
+                return;
+        }
+    }
+
     render() {
         if(this.rdvPossible) {
             const plateforme: Plateforme|undefined = PLATEFORMES[this.lieu.plateforme];
@@ -90,7 +104,7 @@ export class VmdAppointmentCardComponent extends LitElement {
 
                         ${this.estCliquable?html`
                         <div class="col-24 col-md-auto text-center mt-4 mt-md-0">
-                            <span tabindex="0" role="link" data-href="${this.lieu.url}" class="btn btn-primary btn-lg">
+                            <span class="btn btn-primary btn-lg" tabindex="0" role="link" data-href="${this.lieu.url}" @keydown="${(event) => this.makeEnterAsClick(event, 'prendreRdv')}">
                               Prendre rendez-vous
                             </span>
                             <div class="row align-items-center justify-content-center mt-3 text-black-50">
@@ -134,7 +148,7 @@ export class VmdAppointmentCardComponent extends LitElement {
 
                     ${this.estCliquable?html`
                     <div class="col-24 col-md-auto text-center mt-4 mt-md-0">
-                      <span tabindex="0" role="link" data-href="${this.lieu.url}" class="btn btn-info btn-lg">Vérifier le centre de vaccination</span>
+                      <span class="btn btn-info btn-lg" tabindex="0" role="link" data-href="${this.lieu.url}" @keydown="${(event) => this.makeEnterAsClick(event, 'verifierRdv')}">Vérifier le centre de vaccination</span>
                     </div>
                     `:html``}
                   </div>

--- a/src/components/vmd-appointment-card.component.ts
+++ b/src/components/vmd-appointment-card.component.ts
@@ -89,7 +89,7 @@ export class VmdAppointmentCardComponent extends LitElement {
 
                         ${this.estCliquable?html`
                         <div class="col-24 col-md-auto text-center mt-4 mt-md-0">
-                            <a href="${this.estCliquable ? this.lieu.url : '#'}" class="btn btn-primary btn-lg">
+                            <a href="${this.lieu.url}" class="btn btn-primary btn-lg">
                               Prendre rendez-vous
                             </a>
                             <div class="row align-items-center justify-content-center mt-3 text-black-50">

--- a/src/components/vmd-appointment-card.component.ts
+++ b/src/components/vmd-appointment-card.component.ts
@@ -46,20 +46,6 @@ export class VmdAppointmentCardComponent extends LitElement {
         }));
     }
 
-    makeEnterAsClick(event: Event, type: String) {
-        if (event.key !== 'Enter') {
-            return;
-        }
-        switch (type) {
-            case 'prendreRdv':
-                return this.prendreRdv();
-            case 'verifierRdv':
-                return this.verifierRdv();
-            default:
-                return;
-        }
-    }
-
     render() {
         if(this.rdvPossible) {
             const plateforme: Plateforme|undefined = PLATEFORMES[this.lieu.plateforme];
@@ -104,9 +90,7 @@ export class VmdAppointmentCardComponent extends LitElement {
 
                         ${this.estCliquable?html`
                         <div class="col-24 col-md-auto text-center mt-4 mt-md-0">
-                            <span class="btn btn-primary btn-lg" tabindex="0" role="link" data-href="${this.lieu.url}" @keydown="${(event) => this.makeEnterAsClick(event, 'prendreRdv')}">
-                              Prendre rendez-vous
-                            </span>
+                            <a class="btn btn-primary btn-lg" href="#">Prendre rendez-vous</a>
                             <div class="row align-items-center justify-content-center mt-3 text-black-50">
                                 <div class="col-auto">
                                   ${this.lieu.appointment_count.toLocaleString()} dose${Strings.plural(this.lieu.appointment_count)}
@@ -148,7 +132,7 @@ export class VmdAppointmentCardComponent extends LitElement {
 
                     ${this.estCliquable?html`
                     <div class="col-24 col-md-auto text-center mt-4 mt-md-0">
-                      <span class="btn btn-info btn-lg" tabindex="0" role="link" data-href="${this.lieu.url}" @keydown="${(event) => this.makeEnterAsClick(event, 'verifierRdv')}">Vérifier le centre de vaccination</span>
+                      <a class="btn btn-info btn-lg" href="#">Vérifier le centre de vaccination</a>
                     </div>
                     `:html``}
                   </div>

--- a/src/components/vmd-appointment-card.component.ts
+++ b/src/components/vmd-appointment-card.component.ts
@@ -56,7 +56,7 @@ export class VmdAppointmentCardComponent extends LitElement {
               distance = distance.toFixed(1)
             }
             return html`
-            <div class="card rounded-3 mb-5 p-4 ${classMap({clickable: this.estCliquable})}"
+            <div class="card rounded-3 mb-5 p-4 ${classMap({clickable: this.estCliquable})}" title="${this.estCliquable ? this.lieu.url : ''}"
                  @click="${() => this.prendreRdv()}">
                 <div class="card-body">
                     <div class="row align-items-center ">
@@ -115,7 +115,9 @@ export class VmdAppointmentCardComponent extends LitElement {
             `;
         } else {
             return html`
-              <div class="card rounded-3 mb-5 p-4 bg-disabled" @click="${() => this.verifierRdv()}">
+              <div title="${this.estCliquable ? this.lieu.url : ''}"
+                class="card rounded-3 mb-5 p-4 bg-disabled ${classMap({clickable: this.estCliquable})}"
+                @click="${() => this.verifierRdv()}">
                 <div class="card-body">
                   <div class="row align-items-center">
                     <div class="col">

--- a/src/components/vmd-appointment-card.component.ts
+++ b/src/components/vmd-appointment-card.component.ts
@@ -89,7 +89,7 @@ export class VmdAppointmentCardComponent extends LitElement {
 
                         ${this.estCliquable?html`
                         <div class="col-24 col-md-auto text-center mt-4 mt-md-0">
-                            <a href="#" class="btn btn-primary btn-lg">
+                            <a href="${this.estCliquable ? this.lieu.url : '#'}" class="btn btn-primary btn-lg">
                               Prendre rendez-vous
                             </a>
                             <div class="row align-items-center justify-content-center mt-3 text-black-50">
@@ -133,7 +133,7 @@ export class VmdAppointmentCardComponent extends LitElement {
 
                     ${this.estCliquable?html`
                     <div class="col-24 col-md-auto text-center mt-4 mt-md-0">
-                      <a href="#" class="btn btn-info btn-lg">Vérifier le centre de vaccination</a>
+                      <a href="${this.lieu.url}" class="btn btn-info btn-lg">Vérifier le centre de vaccination</a>
                     </div>
                     `:html``}
                   </div>

--- a/src/views/vmd-rdv.view.ts
+++ b/src/views/vmd-rdv.view.ts
@@ -210,13 +210,13 @@ export abstract class AbstractVmdRdvView extends LitElement {
 
                 <div class="resultats px-2 py-5 text-dark bg-light rounded-3">
                     ${repeat(this.lieuxParDepartementAffiches?this.lieuxParDepartementAffiches.lieuxDisponibles:[], (c => `${c.departement}||${c.nom}||${c.plateforme}}`), (lieu, index) => {
-                        return html`<vmd-appointment-card 
-                            style="--list-index: ${index}" 
-                            .lieu="${lieu}" 
-                            .rdvPossible="${true}" 
+                        return html`<vmd-appointment-card
+                            style="--list-index: ${index}"
+                            .lieu="${lieu}"
+                            .rdvPossible="${true}"
                             .distance="${lieu.distance}"
                             @prise-rdv-cliquee="${(event: LieuCliqueCustomEvent) => this.prendreRdv(event.detail.lieu)}"
-                            @verification-rdv-cliquee="${(event: LieuCliqueCustomEvent) => this.verifierRdv(event.detail.lieu)}"
+                            @verification-rdv-cliquee="${(event: LieuCliqueCustomEvent) =>  this.verifierRdv(event.detail.lieu)}"
                         />`;
                     })}
 
@@ -231,7 +231,13 @@ export abstract class AbstractVmdRdvView extends LitElement {
                     </h5>
 
                     ${repeat(this.lieuxParDepartementAffiches.lieuxIndisponibles || [], (c => `${c.departement}||${c.nom}||${c.plateforme}`), (lieu, index) => {
-                        return html`<vmd-appointment-card style="--list-index: ${index}" .lieu="${lieu}" .rdvPossible="${false}"></vmd-appointment-card>`;
+                        return html`<vmd-appointment-card
+                            style="--list-index: ${index}"
+                            .lieu="${lieu}"
+                            .rdvPossible="${false}"
+                            @prise-rdv-cliquee="${(event: LieuCliqueCustomEvent) => this.prendreRdv(event.detail.lieu)}"
+                            @verification-rdv-cliquee="${(event: LieuCliqueCustomEvent) =>  this.verifierRdv(event.detail.lieu)}"
+                        ></vmd-appointment-card>`;
                     })}
                   ` : html``}
                 </div>


### PR DESCRIPTION
Hello, I discovered this project and wanted to help.
So I found some problems with the appointment list and tried to fix them.
Feel free to make all the reviews you want, I will be reactive ;)

Several problems have been reported, and I discovered the others:

- It is not possible to know which link we open when clicking on an appointment https://github.com/CovidTrackerFr/vitemadose-front/issues/84
- Accessibility can be improved by using a href https://github.com/CovidTrackerFr/vitemadose-front/pull/53
- "Other" centres are clickable (in the current online version, not in the code), but it is not easy to discover this feature (no mouse cursor, no background color when hovering over the items)
- Links and analysis are broken for "other" centres because the "@verification-rdv-cliquee" event is not passed

## Todo

- [x] Add a background color to indicate that the "Vérifier le centre" card is clickable
- [x] Add the link in a title around the card (Issue #84). It's kind of a workaround because it's not possible to encapsulate the whole card into a link.
- [x] Fill the missing hrefs with the vaccination centres links
- [x] Fix the analytics by setting the correct event to the other centres

## Screenshots

- Show the vaccination centre url:

![Sélection_002](https://user-images.githubusercontent.com/5584839/115786698-74e34880-a3c1-11eb-8d3b-d582427cf1f2.png)

- Show the new background:

![Peek 22-04-2021 22-34](https://user-images.githubusercontent.com/5584839/115786775-8e849000-a3c1-11eb-863e-4d831928830e.gif)

PS: Le projet est vraiment chouette.
PS2: J'ai posté en anglais par habitude, mais vous pouvez me répondre en français ;)