### PR TITLE
Rajout d'un bouton permettant de rafraichir la liste des centres

### DIFF
--- a/src/state/State.ts
+++ b/src/state/State.ts
@@ -173,8 +173,8 @@ export class State {
     }
 
     private _lieuxParDepartement: LieuxParDepartements = new Map<CodeDepartement, LieuxParDepartement>();
-    async lieuxPour(codeDepartement: CodeDepartement): Promise<LieuxParDepartement> {
-        if(this._lieuxParDepartement.has(codeDepartement)) {
+    async lieuxPour(codeDepartement: CodeDepartement, avoidCache: boolean = false): Promise<LieuxParDepartement> {
+        if(this._lieuxParDepartement.has(codeDepartement) && !avoidCache) {
             return Promise.resolve(this._lieuxParDepartement.get(codeDepartement)!);
         } else {
             const resp = await fetch(`${VMD_BASE_URL}/${codeDepartement}.json`)

--- a/src/utils/Schedulers.ts
+++ b/src/utils/Schedulers.ts
@@ -1,0 +1,17 @@
+
+
+export const setDebouncedInterval = function(handler: Function, duration?: number, ...args: any[]) {
+    let ongoingHandler = false;
+    return setInterval(async () => {
+        if(ongoingHandler) {
+            console.warn("Skipped setDebouncedInterval()'s handler as ongoing already");
+            return;
+        }
+        try {
+            ongoingHandler = true;
+            await handler(...args);
+        } finally {
+            ongoingHandler = false;
+        }
+    }, duration);
+}

--- a/src/views/vmd-rdv.view.ts
+++ b/src/views/vmd-rdv.view.ts
@@ -29,6 +29,7 @@ import {ValueStrCustomEvent} from "../components/vmd-selector.component";
 import {TemplateResult} from "lit-html";
 import {Analytics} from "../utils/Analytics";
 import {LieuCliqueCustomEvent} from "../components/vmd-appointment-card.component";
+import {setDebouncedInterval} from "../utils/Schedulers";
 
 const MAX_DISTANCE_CENTRE_IN_KM = 100;
 
@@ -278,14 +279,14 @@ export abstract class AbstractVmdRdvView extends LitElement {
 
         await this.onceStartupPromiseResolved();
 
-        this.lieuBackgroundRefreshIntervalId = setInterval(async () => {
+        this.lieuBackgroundRefreshIntervalId = setDebouncedInterval(async () => {
             if(this.codeDepartementSelectionne) {
                 const derniereMiseAJour = this.lieuxParDepartementAffiches?this.lieuxParDepartementAffiches.derniereMiseAJour:undefined;
                 const lieuxAJourPourDepartement = await State.current.lieuxPour(this.codeDepartementSelectionne, true)
                 this.miseAJourDisponible = (derniereMiseAJour !== lieuxAJourPourDepartement.derniereMiseAJour);
 
                 // Used only to refresh derniereMiseAJour's displayed relative time
-                this.requestUpdate();
+                await this.requestUpdate();
             }
         }, 45000);
     }


### PR DESCRIPTION
Le bouton n'est affiché que si on détecte une mise à jour.

Le changement permet également de rafraichir la durée qui s'est écoulée depuis la dernière mise à jour.

La vérification se fait toutes les 45s en tache de fond (et nécessite de récupérer le fichier centre, qui fait 8Ko au pire ces temps-ci).

Ça donne quelque chose comme ça :
<img width="1108" alt="Vaccination_COVID-19_à_Villenave-d_Ornon_33140" src="https://user-images.githubusercontent.com/603815/115792312-5b92ca00-a3ca-11eb-8f0b-faccec1b9e7e.png">

Fixes #110
