### PR TITLE
Fix the search for Corsican departments 2A and 2B

### DIFF
--- a/src/components/vmd-commune-selector.component.ts
+++ b/src/components/vmd-commune-selector.component.ts
@@ -217,6 +217,20 @@ export class VmdCommuneOrDepartmentSelectorComponent extends VmdCommuneSelectorC
     @property({type: Array, attribute: false}) departementsDisponibles: Departement[] = [];
     @property({type: Array, attribute: false}) departementsAffiches: Departement[] = [];
 
+    get showDropdown() {
+        if (!this.inputHasFocus) {
+            return false;
+        }
+        switch(this.inputMode) {
+            case 'text':
+                return (this.communesAffichees && this.communesAffichees.length) || (this.departementsAffiches && this.departementsAffiches.length)
+            case 'numeric':
+                return true;
+            default:
+                return false;
+            }
+    }
+
     departementSelectionne(dpt: Departement) {
         this.filter = `${dpt.code_departement} - ${dpt.nom_departement}`;
         this.communesDisponibles = [];

--- a/src/components/vmd-commune-selector.component.ts
+++ b/src/components/vmd-commune-selector.component.ts
@@ -49,9 +49,12 @@ export class VmdCommuneSelectorComponent extends LitElement {
     private filterMatchingAutocomplete: string|undefined = undefined;
 
     get showDropdown() {
-        return this.inputHasFocus
-            && ((this.inputMode === 'text' && this.communesAffichees && this.communesAffichees.length)
-                || this.inputMode === 'numeric');
+        if (!this.inputHasFocus) {
+            return false;
+        }
+        return this.inputMode === 'text' ?
+            this.communesAffichees && this.communesAffichees.length
+            : this.inputMode === 'numeric';
     }
 
     get communeSelectionnee(): Commune | undefined {
@@ -83,7 +86,7 @@ export class VmdCommuneSelectorComponent extends LitElement {
         // Retrieving current filter
         this.filter = (event.currentTarget as HTMLInputElement).value;
 
-        // If we previously matched an autocomplete filter previously, checking that what we matched
+        // If we previously matched an autocomplete filter, checking that what we matched
         // is still at the 'start' of current filter
         // This is intended to detected start of filter string modifications which would invalidate
         // the current autocompleteFilter
@@ -221,14 +224,9 @@ export class VmdCommuneOrDepartmentSelectorComponent extends VmdCommuneSelectorC
         if (!this.inputHasFocus) {
             return false;
         }
-        switch(this.inputMode) {
-            case 'text':
-                return (this.communesAffichees && this.communesAffichees.length) || (this.departementsAffiches && this.departementsAffiches.length)
-            case 'numeric':
-                return true;
-            default:
-                return false;
-            }
+        return this.inputMode === 'text' ?
+            (this.communesAffichees && this.communesAffichees.length) || (this.departementsAffiches && this.departementsAffiches.length)
+            : this.inputMode === 'numeric';
     }
 
     departementSelectionne(dpt: Departement) {

--- a/src/components/vmd-commune-selector.component.ts
+++ b/src/components/vmd-commune-selector.component.ts
@@ -161,7 +161,7 @@ export class VmdCommuneSelectorComponent extends LitElement {
                    @focusin="${() => { this.inputHasFocus = true; }}"
                    @focusout="${this.hideDropdownWhenInputHasNotFocus}"
                    @keyup="${this.valueChanged}" .value="${this.filter}"
-                   inputmode="${this.inputMode}" placeholder="${this.inputModeFixedToText?'Commune, Code postal, Département...':this.inputMode==='numeric'?'Saisissez un code postal':'Saisissez un nom de commune'}" 
+                   inputmode="${this.inputMode}" placeholder="${this.inputModeFixedToText?'Commune, Code postal, Département...':this.inputMode==='numeric'?'Saisissez un code postal':'Saisissez un nom de commune'}"
             />
             ${this.filter?html`
             <button class="autocomplete-button" @click="${() => { this.filter = ''; this.shadowRoot!.querySelector("input")!.focus(); } }"><span>X</span></button>

--- a/src/components/vmd-commune-selector.component.ts
+++ b/src/components/vmd-commune-selector.component.ts
@@ -253,10 +253,11 @@ export class VmdCommuneOrDepartmentSelectorComponent extends VmdCommuneSelectorC
         const fullTextSearchableQuery = Strings.toFullTextSearchableString(this.filter)
 
         this.departementsAffiches = this.departementsDisponibles?this.departementsDisponibles.filter(dpt => {
-            const fullTextSearchableNomCommune = Strings.toFullTextSearchableString(dpt.nom_departement)
+            const fullTextSearchableDptCode = Strings.toFullTextSearchableString(dpt.code_departement)
+            const fullTextSearchableDptName = Strings.toFullTextSearchableString(dpt.nom_departement)
 
-            return dpt.code_departement.indexOf(fullTextSearchableQuery) === 0
-                || fullTextSearchableNomCommune.indexOf(fullTextSearchableQuery) !== -1;
+            return fullTextSearchableDptCode.indexOf(fullTextSearchableQuery) === 0
+                || fullTextSearchableDptName.indexOf(fullTextSearchableQuery) !== -1;
         }):[];
     }
 


### PR DESCRIPTION
Fixing https://github.com/CovidTrackerFr/vitemadose-front/issues/123

The first issue was a comparison between 2A in uppercase and 2a in lowercase. Now the codes are lowercased before comparing them.

I also spotted a hidden issue by fixing the search: the drop-down was only displayed if the search contained also cities.

Searching for 21 **worked**:
- 21 - Côte d'Or (**dpt**)
- 21700 - Agencourt (**city**)
- ...

Searching for 2B **didn't work**:
- 2B - Corse (**dpt**)
- No other choices

That's why I also changed the `showDropdown` accessor.

## Todo

- [x] Compare department codes in lowercase (2A !== 2a)
- [x] Fix displaying the drop down for departments

## Screenshots

**It's now possible to enter 2A in the search**

![Peek 28-04-2021 15-38](https://user-images.githubusercontent.com/5584839/116413988-628d6280-a838-11eb-9c62-323f7f163ae6.gif)

**Other ways to search still work**

![Sélection_004](https://user-images.githubusercontent.com/5584839/116414067-75a03280-a838-11eb-8df5-434f6b6379f8.png)
![Sélection_005](https://user-images.githubusercontent.com/5584839/116414135-818bf480-a838-11eb-8530-b5a589283311.png)
![Sélection_006](https://user-images.githubusercontent.com/5584839/116414170-894b9900-a838-11eb-908c-f1cf0fdf3e8f.png)
