### PR TITLE
Fix recherche dpt corse

### DIFF
--- a/src/components/vmd-commune-selector.component.ts
+++ b/src/components/vmd-commune-selector.component.ts
@@ -229,9 +229,21 @@ export class VmdCommuneSelectorComponent extends LitElement {
 }
 
 
+type DepartementRecherchable = Departement & {
+    fullTextSearchableNom: string;
+    fullTextSearchableCodeDepartement: string;
+};
+
 @customElement('vmd-commune-or-departement-selector')
 export class VmdCommuneOrDepartmentSelectorComponent extends VmdCommuneSelectorComponent {
-    @property({type: Array, attribute: false}) departementsDisponibles: Departement[] = [];
+    @property({type: Array, attribute: false}) set departementsDisponibles(dpts: Departement[]) {
+        this.departementsCherchables = dpts.map(d => ({...d,
+            fullTextSearchableCodeDepartement: Strings.toFullTextSearchableString(d.code_departement),
+            fullTextSearchableNom: Strings.toFullTextSearchableString(d.nom_departement)
+        }));
+    }
+    @internalProperty() departementsCherchables: DepartementRecherchable[] = [];
+
     @property({type: Array, attribute: false}) departementsAffiches: Departement[] = [];
 
     departementSelectionne(dpt: Departement) {
@@ -259,12 +271,10 @@ export class VmdCommuneOrDepartmentSelectorComponent extends VmdCommuneSelectorC
     private filtrerDepartementsAffichees() {
         const fullTextSearchableQuery = Strings.toFullTextSearchableString(this.filter)
 
-        this.departementsAffiches = this.departementsDisponibles?this.departementsDisponibles.filter(dpt => {
-            const fullTextSearchableNomCommune = Strings.toFullTextSearchableString(dpt.nom_departement)
-
-            return dpt.code_departement.indexOf(fullTextSearchableQuery) === 0
-                || fullTextSearchableNomCommune.indexOf(fullTextSearchableQuery) !== -1;
-        }):[];
+        this.departementsAffiches = this.departementsCherchables.filter(dpt => {
+            return dpt.fullTextSearchableCodeDepartement.indexOf(fullTextSearchableQuery) === 0
+                || dpt.fullTextSearchableNom.indexOf(fullTextSearchableQuery) !== -1;
+        });
     }
 
     renderListItems(): TemplateResult|DirectiveFn {

--- a/src/components/vmd-commune-selector.component.ts
+++ b/src/components/vmd-commune-selector.component.ts
@@ -58,7 +58,8 @@ export class VmdCommuneSelectorComponent extends LitElement {
 
     get showDropdown() {
         return this.inputHasFocus
-            && ((this.inputMode === 'text' && this.communesAffichees && this.communesAffichees.length)
+            && this.filter
+            && ((this.inputMode === 'text' && !this.dropDownVide())
                 || this.inputMode === 'numeric');
     }
 
@@ -68,6 +69,14 @@ export class VmdCommuneSelectorComponent extends LitElement {
             return communesDisponibles.find(c => c.code === this.codeCommuneSelectionne);
         }
         return undefined;
+    }
+
+    protected aucuneCommuneAffichee(): boolean {
+        return !this.communesAffichees || !this.communesAffichees.length;
+    }
+
+    protected dropDownVide(): boolean {
+        return this.aucuneCommuneAffichee();
     }
 
     private filtrerCommunesAffichees() {
@@ -183,7 +192,7 @@ export class VmdCommuneSelectorComponent extends LitElement {
             `:html``}
             ${this.showDropdown?html`
               <ul class="autocomplete-results">
-                ${(this.inputMode==='numeric' && (!this.communesAffichees || !this.communesAffichees.length))?html`
+                ${(this.inputMode==='numeric' && this.aucuneCommuneAffichee())?html`
                 <li class="autocomplete-result switch-to-text" @click="${() => { this.inputMode='text'; this.shadowRoot!.querySelector("input")!.focus(); }}"><em>Je ne connais pas le code postal</em></li>
                 `:html``}
                 ${this.renderListItems()}
@@ -241,6 +250,10 @@ export class VmdCommuneOrDepartmentSelectorComponent extends VmdCommuneSelectorC
         super.valueChanged(event);
 
         this.filtrerDepartementsAffichees();
+    }
+
+    protected dropDownVide(): boolean {
+        return this.aucuneCommuneAffichee() && !this.departementsAffiches.length;
     }
 
     private filtrerDepartementsAffichees() {

--- a/src/components/vmd-commune-selector.component.ts
+++ b/src/components/vmd-commune-selector.component.ts
@@ -59,6 +59,10 @@ export class VmdCommuneSelectorComponent extends LitElement {
     get showDropdown() {
         return this.inputHasFocus
             && this.filter
+            // This one is done because otherwise we would start showing some departments matching
+            // first digit, and this would encourage search by department (whereas search by commune
+            // is by far better)
+            && this.filter.length >= 2
             && ((this.inputMode === 'text' && !this.dropDownVide())
                 || this.inputMode === 'numeric');
     }

--- a/src/components/vmd-commune-selector.component.ts
+++ b/src/components/vmd-commune-selector.component.ts
@@ -1,4 +1,12 @@
-import {css, customElement, html, LitElement, property, unsafeCSS} from 'lit-element';
+import {
+    css,
+    customElement,
+    html,
+    internalProperty,
+    LitElement,
+    property,
+    unsafeCSS
+} from 'lit-element';
 import {classMap} from "lit-html/directives/class-map";
 import {Commune, Departement} from "../state/State";
 import {repeat} from "lit-html/directives/repeat";
@@ -26,12 +34,12 @@ export class VmdCommuneSelectorComponent extends LitElement {
 
     @property({type: String}) codeCommuneSelectionne: string | undefined = undefined;
 
-    @property({type: Boolean, attribute: false}) inputHasFocus: boolean = false;
+    @internalProperty() inputHasFocus: boolean = false;
     @property({type: Boolean, attribute: false}) inputModeFixedToText = true;
     @property({type: String, attribute: false}) inputMode: 'numeric'|'text' = 'numeric';
 
     @property({type: Array, attribute: false}) autocompleteTriggers: Set<string>|undefined;
-    @property({type: Boolean, attribute: false}) recuperationCommunesEnCours: boolean = false;
+    @internalProperty() recuperationCommunesEnCours: boolean = false;
     @property({type: Array, attribute: false}) set communesDisponibles(cd: Commune[]|undefined) {
         if(cd !== this._communesDisponibles) {
             this._communesDisponibles = cd;
@@ -43,8 +51,8 @@ export class VmdCommuneSelectorComponent extends LitElement {
     get communesDisponibles(): Commune[]|undefined{ return this._communesDisponibles; }
     private _communesDisponibles: Commune[]|undefined = undefined;
 
-    @property({type: Array, attribute: false}) communesAffichees: Commune[]|undefined = undefined;
-    @property({type: String, attribute: false}) filter: string = "";
+    @internalProperty() communesAffichees: Commune[]|undefined = undefined;
+    @internalProperty() filter: string = "";
 
     private filterMatchingAutocomplete: string|undefined = undefined;
 


### PR DESCRIPTION
fixes #123 

Plusieurs choses :
- Il n'y a pas d'autocomplete sur "2a"/"2b" (car ces préfixes ne matchent aucun nom de commune, ni code postal, qui sont en 20xxx pour la corse) => le matching sur 2a/2b doit se faire au niveau de l'implem avec les département, plutôt qu'au niveau de l'autocomplete
- La dropdown ne s'affiche pas aujourd'hui lorsque la recherche ne match QUE des départements, sans trigger l'autocomplete : j'ai changé ça. Et pour ne pas afficher "trop tôt" (après un seul numéro rentré) un département, j'ai préféré faire en sorte de déclencher l'autocomplete après 2 caractères, afin d'afficher des CP/Communes à coté des Départements en résultat, sinon on aurait pu rentrer "2", et seul les départements en 2* auraient été affiché, sans commune, ce qui aurait encouragé la recherche par département (alors qu'on sait que la recherche par commune est bien plus pertinente niveau résultats ! :))
- Une recherche "stricte" (pas full text, avec lowercase) était faite, ce qui expliquait pourquoi avec un "2a" la recherche ne fonctionnait pas

J'ai fixé tout ça.