### PR TITLE
Search results keyboard navigation

### DIFF
--- a/src/components/vmd-commune-selector.component.scss
+++ b/src/components/vmd-commune-selector.component.scss
@@ -59,6 +59,13 @@ input, .autocomplete {
 
         .autocomplete-results {
             display: block;
+
+            .autocomplete-result {
+                &.autocomplete-active {
+                    background: $primary;
+                    color: $white;
+                }
+            }
         }
     }
 

--- a/src/components/vmd-commune-selector.component.ts
+++ b/src/components/vmd-commune-selector.component.ts
@@ -116,16 +116,16 @@ export class VmdCommuneSelectorComponent extends LitElement {
         }
 
         const removeActiveClassName = () => {
-            for (let i = 0; i < suggestions.length; i++) {
-                if (suggestions[i] != null) {
-                    suggestions[i].classList.remove('autocomplete-active');
-                }
-            }
+            suggestions.forEach(suggestion => {
+                suggestion.classList.remove('autocomplete-active');
+                suggestion.setAttribute('aria-selected', false);
+            })
         }
 
         const addActiveClassName = () => {
             if (suggestions[this.currentFocus] != null) {
                 suggestions[this.currentFocus].classList.add('autocomplete-active');
+                suggestions[this.currentFocus].setAttribute('aria-selected', true);
             }
         }
 
@@ -294,7 +294,7 @@ export class VmdCommuneSelectorComponent extends LitElement {
 
     renderListItems(): TemplateResult|DirectiveFn {
         return repeat(this.communesAffichees || [], (c) => `comm_${c.codePostal}__${c.nom}`, ((commune, index) => {
-            return html`<li class="autocomplete-result" @click="${() => this.communeSelected(commune)}"><span class="zipcode">${commune.codePostal}</span> - ${commune.nom}</li>`
+            return html`<li class="autocomplete-result" aria-label="Commune: ${commune.codePostal} ${commune.nom}" @click="${() => this.communeSelected(commune)}"><span class="zipcode">${commune.codePostal}</span> - ${commune.nom}</li>`
         }));
     }
 
@@ -370,7 +370,7 @@ export class VmdCommuneOrDepartmentSelectorComponent extends VmdCommuneSelectorC
     renderListItems(): TemplateResult|DirectiveFn {
         return html`
             ${repeat(this.departementsAffiches || [], (d) => `dept_${d.code_departement}__${d.nom_departement}`, ((dpt, index) => {
-                return html`<li class="autocomplete-result" @click="${() => this.departementSelectionne(dpt)}"><span class="codeDepartement">${dpt.code_departement}</span> - ${dpt.nom_departement}</li>`
+                return html`<li class="autocomplete-result" aria-label="Département: ${dpt.code_departement} ${dpt.nom_departement}"  @click="${() => this.departementSelectionne(dpt)}"><span class="codeDepartement">${dpt.code_departement}</span> - ${dpt.nom_departement}</li>`
             }))}
             ${super.renderListItems()}
         `;

--- a/src/components/vmd-commune-selector.component.ts
+++ b/src/components/vmd-commune-selector.component.ts
@@ -5,7 +5,6 @@ import {
     internalProperty,
     LitElement,
     property,
-    queryAll,
     unsafeCSS
 } from 'lit-element';
 import {classMap} from "lit-html/directives/class-map";
@@ -17,7 +16,6 @@ import {Strings} from "../utils/Strings";
 import {TemplateResult} from "lit-html";
 import {DirectiveFn} from "lit-html/lib/directive";
 
-
 export type AutocompleteTriggered = { value: string };
 export type CommuneSelected = { commune: Commune };
 export type DepartementSelected = { departement: Departement };
@@ -26,11 +24,11 @@ const KEY_CODE_ARROW_DOWN = 40;
 const KEY_CODE_ARROW_UP = 38;
 const KEY_CODE_ARROW_ENTER = 13;
 
+const DEFAULT_FOCUS = -1;
+const SUGGESTIONS_PER_PAGE = 5;
+
 @customElement('vmd-commune-selector')
 export class VmdCommuneSelectorComponent extends LitElement {
-    // @queryAll('li.autocomplete-result')
-    // _autocompleteResults;
-
     //language=css
     static styles = [
         css`${unsafeCSS(globalCss)}`,
@@ -61,7 +59,7 @@ export class VmdCommuneSelectorComponent extends LitElement {
     @internalProperty() communesAffichees: Commune[]|undefined = undefined;
     @internalProperty() filter: string = "";
 
-    @property({type: Number}) currentFocus: number = -1;
+    @property({type: Number}) currentFocus: number = DEFAULT_FOCUS;
 
     private filterMatchingAutocomplete: string|undefined = undefined;
 
@@ -113,10 +111,6 @@ export class VmdCommuneSelectorComponent extends LitElement {
         const suggestionContainer = this.shadowRoot?.querySelector('ul.autocomplete-results');
         const suggestions = this.shadowRoot?.querySelectorAll('li.autocomplete-result');
 
-        const DEFAULT_FOCUS = -1;
-        const SUGGESTIONS_PER_PAGE = 5;
-
-
         if (!suggestions) {
             return;
         }
@@ -153,7 +147,7 @@ export class VmdCommuneSelectorComponent extends LitElement {
             removeActiveClassName();
             addActiveClassName();
 
-            if (this.currentFocus <= suggestions?.length - SUGGESTIONS_PER_PAGE) {
+            if (this.currentFocus !== DEFAULT_FOCUS && this.currentFocus <= suggestions.length - SUGGESTIONS_PER_PAGE) {
               suggestionContainer.scrollTop -= suggestions[this.currentFocus].clientHeight;
             }
         }

--- a/src/components/vmd-commune-selector.component.ts
+++ b/src/components/vmd-commune-selector.component.ts
@@ -24,7 +24,7 @@ const KEY_CODE_ARROW_DOWN = 40;
 const KEY_CODE_ARROW_UP = 38;
 const KEY_CODE_ARROW_ENTER = 13;
 
-const DEFAULT_FOCUS = -1;
+const NOT_FOCUSED = -1;
 const SUGGESTIONS_PER_PAGE = 5;
 
 @customElement('vmd-commune-selector')
@@ -59,7 +59,7 @@ export class VmdCommuneSelectorComponent extends LitElement {
     @internalProperty() communesAffichees: Commune[]|undefined = undefined;
     @internalProperty() filter: string = "";
 
-    @property({type: Number}) currentFocus: number = DEFAULT_FOCUS;
+    @property({type: Number}) currentFocus: number = NOT_FOCUSED;
 
     private filterMatchingAutocomplete: string|undefined = undefined;
 
@@ -111,7 +111,7 @@ export class VmdCommuneSelectorComponent extends LitElement {
         const suggestionContainer = this.shadowRoot?.querySelector('ul.autocomplete-results');
         const suggestions = this.shadowRoot?.querySelectorAll('li.autocomplete-result');
 
-        if (!suggestions) {
+        if (!suggestions || suggestions.length === 0) {
             return;
         }
 
@@ -131,34 +131,38 @@ export class VmdCommuneSelectorComponent extends LitElement {
 
         const handleArrowDown = () => {
             this.currentFocus++;
-            removeActiveClassName();
-            addActiveClassName();
 
             if (this.currentFocus >= suggestions.length) {
-                this.currentFocus = DEFAULT_FOCUS;
+                this.currentFocus = NOT_FOCUSED; // Loop among the suggestions
                 suggestionContainer.scrollTop = 0;
             } else if (this.currentFocus >= SUGGESTIONS_PER_PAGE) {
                 suggestionContainer.scrollTop += suggestions[this.currentFocus].clientHeight;
             }
+
+            removeActiveClassName();
+            addActiveClassName();
         }
 
         const handleArrowUp = () => {
-            this.currentFocus--;
+            if (this.currentFocus > NOT_FOCUSED + 1) {
+                this.currentFocus--;
+            }
+
+            if (this.currentFocus > NOT_FOCUSED && this.currentFocus <= suggestions.length - SUGGESTIONS_PER_PAGE) {
+                suggestionContainer.scrollTop -= suggestions[this.currentFocus].clientHeight;
+            }
+
             removeActiveClassName();
             addActiveClassName();
-
-            if (this.currentFocus !== DEFAULT_FOCUS && this.currentFocus <= suggestions.length - SUGGESTIONS_PER_PAGE) {
-              suggestionContainer.scrollTop -= suggestions[this.currentFocus].clientHeight;
-            }
         }
 
         const handleEnter = () => {
-            if (this.currentFocus > DEFAULT_FOCUS) {
+            if (this.currentFocus > NOT_FOCUSED) {
                 suggestions[this.currentFocus].click();
             }
 
             removeActiveClassName();
-            this.currentFocus = DEFAULT_FOCUS;
+            this.currentFocus = NOT_FOCUSED;
         }
 
         switch(event.keyCode) {

--- a/src/components/vmd-commune-selector.component.ts
+++ b/src/components/vmd-commune-selector.component.ts
@@ -181,8 +181,10 @@ export class VmdCommuneSelectorComponent extends LitElement {
             <input type="text" class="autocomplete-input"
                    @focusin="${() => { this.inputHasFocus = true; }}"
                    @focusout="${this.hideDropdownWhenInputHasNotFocus}"
-                   @keyup="${this.valueChanged}" .value="${this.filter}"
-                   inputmode="${this.inputMode}" placeholder="${this.inputModeFixedToText?'Commune, Code postal, Département...':this.inputMode==='numeric'?'Saisissez un code postal':'Saisissez un nom de commune'}" 
+                   @keyup="${this.valueChanged}"
+                   .value="${this.filter}"
+                   inputmode="${this.inputMode}"
+                   placeholder="${this.inputModeFixedToText?'Commune, Code postal, Département...':this.inputMode==='numeric'?'Saisissez un code postal':'Saisissez un nom de commune'}"
             />
             ${this.filter?html`
             <button class="autocomplete-button" @click="${() => { this.filter = ''; this.shadowRoot!.querySelector("input")!.focus(); } }"><span>X</span></button>

--- a/src/components/vmd-commune-selector.component.ts
+++ b/src/components/vmd-commune-selector.component.ts
@@ -118,14 +118,14 @@ export class VmdCommuneSelectorComponent extends LitElement {
         const removeActiveClassName = () => {
             for (let i = 0; i < suggestions.length; i++) {
                 if (suggestions[i] != null) {
-                    suggestions[i].classList.remove("autocomplete-active");
+                    suggestions[i].classList.remove('autocomplete-active');
                 }
             }
         }
 
         const addActiveClassName = () => {
             if (suggestions[this.currentFocus] != null) {
-                suggestions[this.currentFocus].classList.add("autocomplete-active");
+                suggestions[this.currentFocus].classList.add('autocomplete-active');
             }
         }
 
@@ -167,9 +167,11 @@ export class VmdCommuneSelectorComponent extends LitElement {
 
         switch(event.keyCode) {
             case KEY_CODE_ARROW_DOWN:
+                event.preventDefault();
                 handleArrowDown();
                 return;
             case KEY_CODE_ARROW_UP:
+                event.preventDefault();
                 handleArrowUp();
                 return;
             case KEY_CODE_ARROW_ENTER:


### PR DESCRIPTION
The goal of this PR is to ease the usage of the keyboard when browsing search results.

When search results will be displayed, the user will be able to browse them using the up and down arrows of the keyboard.

My work is inspired by the following example: https://www.w3schools.com/howto/tryit.asp?filename=tryhow_js_autocomplete.

## Todo

- [x] Design the active result
- [x] Catch the keydown event inside the input, and focus the appropriate result
- [x] Add aria labels to the list items

## Screenshots

![Peek 29-04-2021 13-41](https://user-images.githubusercontent.com/5584839/116546029-7052ee80-a8f1-11eb-825d-ac2870673943.gif)
