### PR TITLE
fix(search): 🐛 compare commune - unique ID #108

### DIFF
--- a/src/views/vmd-rdv.view.ts
+++ b/src/views/vmd-rdv.view.ts
@@ -130,7 +130,7 @@ export abstract class AbstractVmdRdvView extends LitElement {
             return;
         }
 
-        if(this.communeSelectionnee.code !== commune.code || this.codeDepartementSelectionne !== commune.codeDepartement) {
+        if(`${this.communeSelectionnee.code}-${this.communeSelectionnee.codePostal}` !== `${commune.code}-${commune.codePostal}` || this.codeDepartementSelectionne !== commune.codeDepartement) {
             this.codeDepartementSelectionne = commune.codeDepartement;
             this.resetCommuneSelectionneeTo(commune);
 


### PR DESCRIPTION
Les villes avec arrondissements n'ont pas de `commune.code` unique.

Reproduction du bug:
- Sur la homepage : cherchez et cliquez sur "13001 - Marseille"
- Ensuite sur la page des résultats : cherchez et cliquez sur "13003 - Marseille"
=> les résultats sont bloqués sur "13001 - Marseille"