### PR TITLE
Régression autocomplete

### DIFF
--- a/src/components/vmd-commune-or-departement-selector.component.ts
+++ b/src/components/vmd-commune-or-departement-selector.component.ts
@@ -239,10 +239,12 @@ export class VmdCommuneOrDepartmentSelectorComponent extends LitElement {
             if(!filterMatchedAnAutocomplete) {
                 this.communesDisponibles = [];
             }
+        }
 
-            if (this.$autoCompleteResults) {
-                this.$autoCompleteResults.scrollTop = 0;
-            }
+        this.filtrerDepartementsAffichees();
+
+        if (this.$autoCompleteResults) {
+            this.$autoCompleteResults.scrollTop = 0;
         }
     }
 

--- a/src/components/vmd-commune-or-departement-selector.component.ts
+++ b/src/components/vmd-commune-or-departement-selector.component.ts
@@ -320,7 +320,7 @@ export class VmdCommuneOrDepartmentSelectorComponent extends LitElement {
       return html`<li
         class="autocomplete-result"
         role="option"
-        aria-selected="${index === 0}"
+        aria-selected="${index === 0 && this.departementsAffiches.length === 0}"
         @click="${() => this.communeSelected(commune)}"
         >
           <span class="zipcode">${commune.codePostal}</span> - ${commune.nom}

--- a/src/components/vmd-commune-or-departement-selector.component.ts
+++ b/src/components/vmd-commune-or-departement-selector.component.ts
@@ -203,7 +203,7 @@ export class VmdCommuneOrDepartmentSelectorComponent extends LitElement {
         // is still at the 'start' of current filter
         // This is intended to detect start of filter string modifications which would invalidate
         // the current autocompleteFilter
-        if(this.filterMatchingAutocomplete && this.filter.includes(this.filterMatchingAutocomplete)) {
+        if(this.filterMatchingAutocomplete && !this.filter.startsWith(this.filterMatchingAutocomplete)) {
             this.filterMatchingAutocomplete = undefined;
         }
 


### PR DESCRIPTION
J'ai détecté 2 régressions sur l'autocomplete : 

- [x] Une fois que la dropdown est affichée, le filtrage ne se fait plus sur les caractères saisis ensuite _(c'était lié au cleanup, lors de d1a847b8f703dad9015c856d14700c907a94044b)_
- [x] Les départements ne sont plus affichés dans la dropdown _(lié au cleanup d1a847b8f703dad9015c856d14700c907a94044b)_
- [x] Lorsqu'on saisissait un code département, à la fois le département et la première commune étaient en `aria-selected=true`