### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,10 +86,10 @@
                 </p>
                 <ul>
                     <li>personnes de 55 ans et plus quel que soit leur lieu de vie et leur état de santé (avec ou sans comorbidités)&nbsp;;</li>
-                    <li>personnes de 50 à 55 ans inclus souffrant d’une pathologie à très haut risque de forme grave de Covid-19 ou d'une ou plusieurs comorbidités&nbsp;;</li>
-                    <li>personnes de 18 à 49 ans inclus souffrant d’une pathologie à très haut risque de forme grave de Covid-19&nbsp;;</li>
+                    <li>personnes de plus de 18 ans souffrant d’une pathologie à très haut risque de forme grave de Covid-19 ;</li>
+                    <li>personnes de 18 à 54 ans inclus souffrant d’une ou plusieurs des comorbidités;</li>
                     <li>personnes majeures en situation de handicap, hébergées en maison d’accueil spécialisée ou foyer d’accueil médicalisé&nbsp;;</li>
-                    <li>adultes vivant dans le même foyer qu’une personne sévèrement immunodéprimée, enfant ou adulte (transplantés d’organes solides, transplantés récents de moelle osseuse récents, patients dialysés, patients atteints de maladies auto-immunes sous traitement immunosuppresseur fort de type anti-CD20 ou anti-métabolites).</li>
+                    <li>les proches (de plus de 16 ans) d'une personne immunodéprimée sur la base d'un certificat médical du médecin traitant de la personne immunodéprimée</li>
                     <li>femmes enceintes à partir du 2e trimestre de grossesse.</li>
                 </ul>
                 <p>Les professionnels de santé et du secteur médico-social sont également éligibles à la vaccination contre la Covid-19.</p>


### PR DESCRIPTION
changements demandés par jeanlouis.baudet pour être conforme aux dernières règles d'éligibilités.

Ligne 2 sur VMD à remplacer par "personnes de plus de 18 ans souffrant d’une pathologie à très haut risque de forme grave de Covid-19 ;"
Ligne 3 sur VMD à remplacer par "personnes de 18 à 54 ans inclus souffrant d’une ou plusieurs des comorbidités;"
Ligne 5 sur VMD à remplacer par "les proches (de plus de 16 ans) d'une personne immunodéprimée sur la base d'un certificat médical du médecin traitant de la personne immunodéprimée"