### PR TITLE
fix(autocomplete): Cancel button incorrectly positioned

### DIFF
--- a/src/components/vmd-commune-or-departement-selector.component.ts
+++ b/src/components/vmd-commune-or-departement-selector.component.ts
@@ -135,7 +135,7 @@ export class VmdCommuneOrDepartmentSelectorComponent extends LitElement {
 
     render() {
         return html`
-          <form class="autocomplete ${classMap({'_open': this.showDropdown, '_withButton': this.filter})}"
+          <form class="autocomplete ${classMap({'_open': this.showDropdown, '_withButton': this.filter !== ''})}"
                 @submit="${this.handleSubmit}">
             <input type="search" class="autocomplete-input"
                    required


### PR DESCRIPTION
Si on écrit 0 dans le champ de recherche.
La croix s'affiche sous le champ.
![image](https://user-images.githubusercontent.com/1426314/117424261-e70b6f80-af21-11eb-9adb-de799506f27d.png)
