### PR TITLE
Correction typos + critères éligibilité

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
                 
                 <hr>
                 <h2 class="h5">Qu'est-ce que Chronodose&nbsp;?</h2>
-                Chronodose est une fonctionnalité permettant de trouver une dose de vaccin Covid19 en 24h pour tous les plus 18 ans, sans condition d'élibilité. Cette fonctionnalité sera déployée sur Vite Ma Dose d'ici au mercredi 12 mai, disponible sur le <u><a href="https://vitemadose.covidtracker.fr">site internet</a></u>, et les applications mobiles (<u><a href="http://apple.co/3dFMGy3">iOS</a></u> et <u><a href="https://play.google.com/store/apps/details?id=com.cvtracker.vmd2">Android</a></u>).<br>
+                Chronodose est une fonctionnalité permettant de trouver une dose de vaccin Covid19 en 24h pour tous les plus 18 ans, sans condition d'éligibilité. Cette fonctionnalité sera déployée sur Vite Ma Dose d'ici au mercredi 12 mai, disponible sur le <u><a href="https://vitemadose.covidtracker.fr">site internet</a></u>, et les applications mobiles (<u><a href="http://apple.co/3dFMGy3">iOS</a></u> et <u><a href="https://play.google.com/store/apps/details?id=com.cvtracker.vmd2">Android</a></u>).<br>
                 Grâce à Chronodose, chaque personne de plus de 18 ans souhaitant se faire vacciner contre la Covid19 pourra chercher un rendez-vous en moins de 24h facilement et rapidement. Un système de notification sera aussi implémenté permettant d'alerter les utilisateurs des disponibilités de créneaux de vaccination Chronodose.
 
                 <hr>
@@ -104,10 +104,12 @@
                 </p>
                 <ul>
                     <li>personnes de 50 ans et plus quel que soit leur lieu de vie et leur état de santé (avec ou sans comorbidités)&nbsp;;</li>
-                    <li>personnes de 18 à 49 ans inclus souffrant d’une pathologie à très haut risque de forme grave de Covid-19&nbsp;;</li>
+                    <li>personnes de 16 à 49 ans inclus souffrant d’une pathologie à très haut risque de forme grave de Covid-19&nbsp;;</li>
+                    <li>personnes de 18 à 49 ans inclus souffrant de comorbidités&nbsp;;</li>
                     <li>personnes majeures en situation de handicap, hébergées en maison d’accueil spécialisée ou foyer d’accueil médicalisé&nbsp;;</li>
-                    <li>adultes vivant dans le même foyer qu’une personne sévèrement immunodéprimée, enfant ou adulte (transplantés d’organes solides, transplantés récents de moelle osseuse récents, patients dialysés, patients atteints de maladies auto-immunes sous traitement immunosuppresseur fort de type anti-CD20 ou anti-métabolites).</li>
-                    <li>femmes enceintes à partir du 2e trimestre de grossesse.</li>
+                    <li>personnes de plus de 16 ans vivant dans le même foyer qu’une personne sévèrement immunodéprimée, enfant ou adulte (transplantés d’organes solides, transplantés récents de moelle osseuse récents, patients dialysés, patients atteints de maladies auto-immunes sous traitement immunosuppresseur fort de type anti-CD20 ou anti-métabolites)&nbsp;;</li>
+                    <li>femmes enceintes à partir du 2e trimestre de grossesse&nbsp;;</li>
+                    <li>futurs assesseurs lors des élections départementales et régionales de juin 2021.</li>
                 </ul>
                 <p>Les professionnels de santé et du secteur médico-social sont également éligibles à la vaccination contre la Covid-19.</p>
                 <p class="fw-light fst-italic">Mis à jour le 10/05/2021</p>
@@ -141,7 +143,7 @@
                 <p>
                     Mesure d’audience&nbsp;: afin de vérifier le bon fonctionnement de notre site internet, nous effectuons
                     <strong>une mesure anonymisée</strong> de l’utilisation du site. À l’exception de ces données de navigation, nous ne partageons
-                    aucune donnée collectée avec d’autres entreprises. Vite Ma Dose ne collecte aucune données personnelles.
+                    aucune donnée collectée avec d’autres entreprises. Vite Ma Dose ne collecte aucune donnée personnelle.
                 </p>
 
                 <hr>

--- a/src/views/vmd-statistiques.view.ts
+++ b/src/views/vmd-statistiques.view.ts
@@ -42,7 +42,7 @@ export class VmdLieuxStatistiques extends LitElement {
 
                       <div class="p-5 text-dark bg-light homeCard-container mt-5">
                         <h3 class="h2"> Créneaux disponibles</h3>
-                        <p>Nombre de créneaux de vaccination disponibles à la réservation pour les prochaines heures ou procains jours. <i><small>Ce chiffre ne correspond pas au nombre de doses.</small></i></p>
+                        <p>Nombre de créneaux de vaccination disponibles à la réservation pour les prochaines heures ou prochains jours. <i><small>Ce chiffre ne correspond pas au nombre de doses.</small></i></p>
                         <vmd-stats-by-date-creneaux-graph class="img-fluid"  width="400" height="150" .data="${this.statsByDates}"></vmd-stats-by-date-creneaux-graph>
                       </div>
                     </div>


### PR DESCRIPTION
Corrections de quelques fautes sur le site :
- élibilité
- aucune données personnelles
- procains jours

Correction des critères d'éligibilités : 
- âge pour les personnes à très haut risque et proches d'immunodéprimées
- personnes souffrant de comorbidités
- assesseurs

