### PR TITLE
Simplification de appointment-metadata

### DIFF
--- a/src/components/vmd-appointment-card.component.scss
+++ b/src/components/vmd-appointment-card.component.scss
@@ -70,7 +70,7 @@
   }
 }
 
-vmd-appointment-metadata [slot='content'] a {
+vmd-appointment-metadata a {
   &:hover {
     color: $link-color
   }

--- a/src/components/vmd-appointment-card.component.ts
+++ b/src/components/vmd-appointment-card.component.ts
@@ -174,27 +174,31 @@ export class VmdAppointmentCardComponent extends LitElement {
                               <small class="distance">${distance ? `- ${distance} km` : ''}</small>
                             </h5>
                             <div class="row">
-                              <vmd-appointment-metadata class="mb-2" widthType="full-width" icon="vmdicon-geo-alt-fill">
-                                <div slot="content">
+                              <vmd-appointment-metadata class="mb-2" widthType="full-width" icon="vmdicon-geo-alt-fill" label="Adresse">
+                                <div>
                                   <span class="fw-bold text-dark">${this.lieu.nom}</span>
                                   <br/>
                                   <em>${this.lieu.metadata.address}</em>
                                 </div>
                               </vmd-appointment-metadata>
-                              <vmd-appointment-metadata class="mb-2" widthType="fit-to-content" icon="vmdicon-telephone-fill" .displayed="${!!this.lieu.metadata.phone_number}">
-                                <span slot="content">
-                                    <a href="tel:${this.lieu.metadata.phone_number}"
-                                       @click="${(e: Event) => { e.stopImmediatePropagation(); }}">
-                                        ${Strings.toNormalizedPhoneNumber(this.lieu.metadata.phone_number)}
-                                    </a>
-                                </span>
+                              ${!!this.lieu.metadata.phone_number ? html`
+                                <vmd-appointment-metadata class="mb-2" widthType="fit-to-content" icon="vmdicon-telephone-fill" label="Téléphone">
+                                  <span>
+                                      <a href="tel:${this.lieu.metadata.phone_number}"
+                                        @click="${(e: Event) => { e.stopImmediatePropagation(); }}">
+                                          ${Strings.toNormalizedPhoneNumber(this.lieu.metadata.phone_number)}
+                                      </a>
+                                  </span>
+                                </vmd-appointment-metadata>
+                              ` : ''} 
+                              <vmd-appointment-metadata class="mb-2" widthType="fit-to-content" icon="vmdicon-commerical-building" label="Lieux">
+                                <span>${TYPES_LIEUX[this.lieu.type]}</span>
                               </vmd-appointment-metadata>
-                              <vmd-appointment-metadata class="mb-2" widthType="fit-to-content" icon="vmdicon-commerical-building">
-                                <span slot="content">${TYPES_LIEUX[this.lieu.type]}</span>
-                              </vmd-appointment-metadata>
-                              <vmd-appointment-metadata class="mb-2" widthType="fit-to-content" icon="vmdicon-syringe" .displayed="${!!this.lieu.vaccine_type}">
-                                <span slot="content">${this.lieu.vaccine_type}</span>
-                              </vmd-appointment-metadata>
+                              ${!!this.lieu.vaccine_type ? html`
+                                <vmd-appointment-metadata class="mb-2" widthType="fit-to-content" icon="vmdicon-syringe" label="Vaccin administré">
+                                  <span>${this.lieu.vaccine_type}</span>
+                                </vmd-appointment-metadata>
+                              ` : ''}
                             </div>
                         </div>
 

--- a/src/components/vmd-appointment-metadata.component.ts
+++ b/src/components/vmd-appointment-metadata.component.ts
@@ -1,5 +1,4 @@
-import {LitElement, html, customElement, property, css } from 'lit-element';
-import {classMap} from "lit-html/directives/class-map";
+import {LitElement, html, customElement, property } from 'lit-element';
 import {CSS_Global} from "../styles/ConstructibleStyleSheets";
 
 export type MetadataWidthType = 'full-width'|'fit-to-content'|'3col-equally-distributed'
@@ -16,18 +15,11 @@ export class VmdAppointmentMetadataComponent extends LitElement {
     //language=css
     static styles = [
         CSS_Global,
-        css`
-        `
     ];
 
-    @property({type: Boolean, attribute: false}) displayed: boolean = true;
-    @property({type: String}) widthType: MetadataWidthType|undefined = undefined;
-    @property({type: String}) icon: string|undefined = undefined;
-    @property({type: Boolean, attribute: false}) centerIconVertically: boolean = true;
-
-    constructor() {
-        super();
-    }
+    @property({type: String}) widthType!: MetadataWidthType;
+    @property({type: String}) icon!: string;
+    @property({type: String}) label!: string;
 
     render() {
         if(!this.widthType) {
@@ -36,10 +28,10 @@ export class VmdAppointmentMetadataComponent extends LitElement {
         }
 
         return html`
-            <div class="row ${classMap({'align-items-center':!!this.centerIconVertically})}">
-                <i class="bi ${this.icon} col-auto"></i>
+            <div class="row">
+                <i class="bi ${this.icon} col-auto" role="img" aria-label="${this.label}"></i>
                 <p class="card-text col text-black-50">
-                  <slot name="content"></slot>
+                  <slot></slot>
                 </p>
             </div>
         `;
@@ -52,14 +44,5 @@ export class VmdAppointmentMetadataComponent extends LitElement {
         if(this.widthType && METADATA_WIDTH_CLASSES[this.widthType]) {
             this.classList.add(METADATA_WIDTH_CLASSES[this.widthType])
         }
-
-        if(!this.displayed) {
-            this.style.display = 'none';
-        }
-    }
-
-    disconnectedCallback() {
-        super.disconnectedCallback();
-        // console.log("disconnected callback")
     }
 }


### PR DESCRIPTION
* [A11y] - Ajout des attributs `aria-label` et `role` pour les icones
* [Perf] - Rendering conditionnel via d'une expression ternaire pour les champs telephone et vaccin pour au lieux de passer la `display: none`
* [Refactor] Suppression de `.centerIconVertically` qui n'est pas utilisé
* [Refactor] Remplacement du `content` par le default slot