### PR TITLE
Added timestamp in center requests

### DIFF
--- a/src/state/State.ts
+++ b/src/state/State.ts
@@ -219,7 +219,8 @@ export class State {
         if(this._lieuxParDepartement.has(codeDepartement) && !avoidCache) {
             return Promise.resolve(this._lieuxParDepartement.get(codeDepartement)!);
         } else {
-            const resp = await fetch(`${VMD_BASE_URL}/${codeDepartement}.json`)
+            const timestamp = +new Date;
+            const resp = await fetch(`${VMD_BASE_URL}/${codeDepartement}.json?timestamp=${timestamp}`)
             const results = await resp.json()
             const lieuxParDepartement = {
                 lieuxDisponibles: results.centres_disponibles.map(transformLieu),


### PR DESCRIPTION
Première PR, je sais pas si c'est ok ?

Ajout d'un timestamp pour les requêtes vers les centres `00.json?timestamp=XXXX` pour éviter le cache forcé sur le disque par les navigateurs.

