### PR TITLE
Évite toujours le cache lorsque l'on récupère les créneaux

### DIFF
--- a/src/state/State.ts
+++ b/src/state/State.ts
@@ -256,22 +256,16 @@ export class State {
       this.autocomplete = new Autocomplete(import.meta.env.BASE_URL, () => this.departementsDisponibles())
     }
 
-    private _lieuxParDepartement: LieuxParDepartements = new Map<CodeDepartement, LieuxParDepartement>();
-    async lieuxPour(codeDepartement: CodeDepartement, avoidCache: boolean = false): Promise<LieuxParDepartement> {
-        if(this._lieuxParDepartement.has(codeDepartement) && !avoidCache) {
-            return Promise.resolve(this._lieuxParDepartement.get(codeDepartement)!);
-        } else {
-            const resp = await fetch(`${VMD_BASE_URL}/${codeDepartement}.json`, { cache: avoidCache ? 'no-cache' : 'default' })
-            const results = await resp.json()
-            const lieuxParDepartement = {
-                lieuxDisponibles: results.centres_disponibles.map(transformLieu),
-                lieuxIndisponibles: results.centres_indisponibles.map(transformLieu),
-                codeDepartements: [codeDepartement],
-                derniereMiseAJour: results.last_updated
-            };
-            this._lieuxParDepartement.set(codeDepartement, lieuxParDepartement);
-            return lieuxParDepartement;
-        }
+    async lieuxPour(codeDepartement: CodeDepartement): Promise<LieuxParDepartement> {
+        const resp = await fetch(`${VMD_BASE_URL}/${codeDepartement}.json`, { cache: 'no-cache' })
+        const results = await resp.json()
+        const lieuxParDepartement = {
+            lieuxDisponibles: results.centres_disponibles.map(transformLieu),
+            lieuxIndisponibles: results.centres_indisponibles.map(transformLieu),
+            codeDepartements: [codeDepartement],
+            derniereMiseAJour: results.last_updated
+        };
+        return lieuxParDepartement;
     }
 
     @Memoize()

--- a/src/views/vmd-rdv.view.ts
+++ b/src/views/vmd-rdv.view.ts
@@ -237,7 +237,7 @@ export abstract class AbstractVmdRdvView extends LitElement {
                         ? currentSearch.departement.code_departement
                         : currentSearch.commune.codeDepartement
                     const derniereMiseAJour = this.lieuxParDepartementAffiches?.derniereMiseAJour
-                    const lieuxAJourPourDepartement = await State.current.lieuxPour(codeDepartement, true)
+                    const lieuxAJourPourDepartement = await State.current.lieuxPour(codeDepartement)
                     this.miseAJourDisponible = (derniereMiseAJour !== lieuxAJourPourDepartement.derniereMiseAJour);
 
                     // we stop the update check if there has been one


### PR DESCRIPTION
Cette PR enlève toute la mécanique de mémoization et ajoute toujours l'option [`cache: 'no-cache'`](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache) lorsque l'on récupère les données de rendez-vous afin d'avoir à coup sûr la donnée la plus fraiche, même après un rafraichissement complet de la page (ce qui est en général le but de la manip).