### PR TITLE
Change base map from OpenStreetMap to Jawg

### DIFF
--- a/src/views/vmd-lieux.view.ts
+++ b/src/views/vmd-lieux.view.ts
@@ -82,9 +82,9 @@ export class VmdLieuxView extends LitElement {
                 console.log("error1")
             });
 
-        tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        tileLayer('https://{s}.tile.jawg.io/jawg-sunny/{z}/{x}/{y}.png?access-token=sOXVrxPultoFMoo0oQigvvfXgPxaX0OFlFJF7y1rw0ZQy1c1yFTSnXSVOBqw0W6Y', {
             maxZoom: 19,
-            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            attribution: '<a href="http://jawg.io" title="Tiles Courtesy of Jawg Maps" target="_blank" class="jawg-attrib">&copy; <b>Jawg</b>Maps</a> | <a href="https://www.openstreetmap.org/copyright" title="OpenStreetMap is open data licensed under ODbL" target="_blank" class="osm-attrib">&copy; OSM contributors</a>            '
         }).addTo(mymap);
     }
 


### PR DESCRIPTION
Bonjour,

Voici un petit changement pour la page `centre`. J'ai changé le fond de plan pour utiliser Jawg Maps au lieu du fond de plan OSM pour plusieurs raisons :

- Le fond de plan OSM est géré par la Fondation OpenStreetMap, ils n'ont pas les ressources pour gérer un flux important d'utilisateurs (on retrouve régulièrement des tuiles grises quand on navigue)
- Ce fond de plan est destiné principalement aux contributeurs (carte un peu trop exhaustive)
- On (Jawg) aimerait mettre à contribution ses ressources pour ce super projet :+1: 

:warning: Cette clé est a usage unique pour les projets Covid Tracker