### PR TITLE
use actions/setup-node@v2 for ci

### DIFF
--- a/.github/workflows/deploy-branches-and-prs.yml
+++ b/.github/workflows/deploy-branches-and-prs.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: "14.12"
       - run: npm ci

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: "14.12"
       - run: npm ci


### PR DESCRIPTION
Cette Pull Request est

- [ ] Un correctif
- [x] Une nouvelle fonctionnalité

### Checklist
- Cette PR vise la branche `dev`
- Elle n'est pas en conflit avec la branche `dev`

### Description
c'est mieux qu'on utilise la `actions/setup-node@v2` pour `github actions` car sur `V2` il peut cacher `node images`, ça peut réduire le temps pour `CI process`

plus d'info est ici https://github.com/actions/setup-node#v2
