### PR TITLE
Ajustement de goutière pour le calendrier

### DIFF
--- a/src/components/vmd-upcoming-days-selector.component.scss
+++ b/src/components/vmd-upcoming-days-selector.component.scss
@@ -3,6 +3,35 @@
 @import "../styles/bootstrap-variables";
 @import "../styles/global-variables";
 
+:host {
+  --day-gutter: 1.6rem;
+}
+
+.scroll-hint {
+  position: relative;
+
+  &::before, &::after {
+    z-index: 10;
+    content: '';
+    position: absolute;
+    display: block;
+    top: 0;
+    height: 100%;
+    width: calc(var(--day-gutter) * 2);
+    height: calc(100% - var(--day-gutter));
+    background: $light;
+    background: linear-gradient(90deg, rgba($light, 255) 20%, transparent 100%);
+  }
+
+  &::before {
+    left: 0;
+  }
+  &::after {
+    right: 0%;
+    transform: rotate(180deg);
+  }
+}
+
 ul.days {
   width: 100%;
   overflow-x: scroll;
@@ -18,7 +47,13 @@ ul.days {
   color: $primary;
   border: 0px;
   border-radius: 1rem;
-  padding: 1.6rem;
+  padding: var(--day-gutter) calc(var(--day-gutter) / 2);
+  &:first-child {
+    padding-left: var(--day-gutter);
+  }
+  &:last-child {
+    padding-right: var(--day-gutter);
+  }
 
   display: flex;
   flex-direction: column;

--- a/src/components/vmd-upcoming-days-selector.component.scss
+++ b/src/components/vmd-upcoming-days-selector.component.scss
@@ -71,6 +71,9 @@ ul.days {
   &.selected .date-card {
     background-color: tint-color($primary, 35%);
     color: white;
+    &::before {
+      transform: translateY(-0.2em);
+    }
   }
   &.empty {
     .date-card {
@@ -91,6 +94,21 @@ ul.days {
     border-radius: 1rem;
     width: 10rem;
     padding: 1rem;
+
+    position: relative;
+    &::before {
+      content: '﹀';
+      position: absolute;
+      display: block;
+      width: 100%;
+      height: var(--day-gutter);
+      text-align: center;
+      bottom: 100%;
+      left: 0;
+      color: $gray-600;
+      transform: translateY(-1em);
+      transition: transform 200ms ease-in-out;
+    }
   }
 
   .weekday {

--- a/src/components/vmd-upcoming-days-selector.component.ts
+++ b/src/components/vmd-upcoming-days-selector.component.ts
@@ -95,33 +95,35 @@ export class VmdUpcomingDaysSelectorComponent extends LitElement {
 
     render() {
         return html`
-          <ul class="days list-group list-group-horizontal">
-            ${repeat(this._upcomingDays, ud => ud.date, ud => {
-                return html`
-              ${(ud.hidden && ud.firstHiddenFromGroup)?html`
-              <li class="list-group-item empty selectable">
-                <div class="date-card" @click="${() => this.showHiddenGroup(ud.hiddenGroup!)}">
-                  Jours sans créneaux
-                </div>
-              </li>
-              `:html``}
-              <li class="list-group-item ${classMap({
-                selected: this.dateSelectionnee === ud.date, 
-                selectable: this.isSelectable(ud),
-                empty: this.dateSelectionnee !== ud.date && ud.total === 0
-              })}" style="${styleMap({ display: ud.hidden?'none':'block' })}" @click="${() => this.jourSelectionne(ud)}">
-                <div class="date-card ${classMap({
-                  'shadow-lg': this.dateSelectionnee === ud.date,
-                  'shadow-sm': this.dateSelectionnee !== ud.date && ud.total>0,
-                })}">
-                  <div class="weekday">${Strings.upperFirst(format(parse(ud.date, 'yyyy-MM-dd', new Date("1970-01-01T00:00:00Z")), 'EEEE', {locale: fr})).replace(".","")}</div>
-                  <div class="day">${Strings.upperFirst(format(parse(ud.date, 'yyyy-MM-dd', new Date("1970-01-01T00:00:00Z")), 'dd/MM', {locale: fr}))}</div>
-                </div>
-                <div class="cpt-rdv">${ud.total>0?html`${ud.total} créneau${Strings.plural(ud.total, "x")}`:html`0 créneaux`}</div>
-              </li>
-                `;
-            })}
-          </ul>
+          <div class="scroll-hint">
+            <ul class="days list-group list-group-horizontal">
+              ${repeat(this._upcomingDays, ud => ud.date, ud => {
+                  return html`
+                ${(ud.hidden && ud.firstHiddenFromGroup)?html`
+                <li class="list-group-item empty selectable">
+                  <div class="date-card" @click="${() => this.showHiddenGroup(ud.hiddenGroup!)}">
+                    Jours sans créneaux
+                  </div>
+                </li>
+                `:html``}
+                <li class="list-group-item ${classMap({
+                  selected: this.dateSelectionnee === ud.date,
+                  selectable: this.isSelectable(ud),
+                  empty: this.dateSelectionnee !== ud.date && ud.total === 0
+                })}" style="${styleMap({ display: ud.hidden?'none':'block' })}" @click="${() => this.jourSelectionne(ud)}">
+                  <div class="date-card ${classMap({
+                    'shadow-lg': this.dateSelectionnee === ud.date,
+                    'shadow-sm': this.dateSelectionnee !== ud.date && ud.total>0,
+                  })}">
+                    <div class="weekday">${Strings.upperFirst(format(parse(ud.date, 'yyyy-MM-dd', new Date("1970-01-01T00:00:00Z")), 'EEEE', {locale: fr})).replace(".","")}</div>
+                    <div class="day">${Strings.upperFirst(format(parse(ud.date, 'yyyy-MM-dd', new Date("1970-01-01T00:00:00Z")), 'dd/MM', {locale: fr}))}</div>
+                  </div>
+                  <div class="cpt-rdv">${ud.total>0?html`${ud.total} créneau${Strings.plural(ud.total, "x")}`:html`0 créneaux`}</div>
+                </li>
+                  `;
+              })}
+            </ul>
+          </div>
         `;
     }
 


### PR DESCRIPTION
Cette Pull Request est

- [x] Un correctif
- [x] Une nouvelle fonctionnalité

### Checklist

- Cette PR vise la branche `dev`
- Elle n'est pas en conflit avec la branche `dev`

### Description

review app : https://dev.vitemado.se/scroll-hint/

+ Ajustement des goutières (padding) pour l'affichage du calendrier pour les créneaux, précédemment la goutière était 2 fois plus grande en largeur.
+ Ajout d'une petit flèche pour le jour selectionné pour que les gens qui voient mal les couleurs (et les autres aussi) puisse mieux le savoir

avant :
![image](https://user-images.githubusercontent.com/235570/127337347-6a666614-c814-49c6-bfbb-fbf04289b995.png)

après :
![image](https://user-images.githubusercontent.com/235570/127476634-0168a544-2efe-4742-8c52-26b5d738dabe.png)




+ Ajout d'un effet de dégradé pour indiquer légèrement que le contenu est scrollable.

![image](https://user-images.githubusercontent.com/235570/127337639-d3b63b6d-a55d-4056-b2a4-d4dd73b96111.png)


