### PR TITLE
Analytics jours resa

### DIFF
--- a/src/views/vmd-rdv.view.ts
+++ b/src/views/vmd-rdv.view.ts
@@ -195,7 +195,7 @@ export abstract class AbstractVmdRdvView extends LitElement {
     @property({type: Boolean, attribute: false}) miseAJourDisponible: boolean = false;
     @property({type: Array, attribute: false}) cartesAffichees: LieuAffichableAvecDistance[] = [];
     @internalProperty() lieuxParDepartement: LieuxParDepartement|undefined = undefined;
-    @internalProperty() protected currentSearch: SearchRequest | void = undefined
+    @internalProperty() protected currentSearch: SearchRequest | undefined = undefined
 
     @internalProperty() jourSelectionne: string|undefined = undefined;
 
@@ -626,7 +626,7 @@ export abstract class AbstractVmdRdvView extends LitElement {
 
 @customElement('vmd-rdv-par-commune')
 export class VmdRdvParCommuneView extends AbstractVmdRdvView {
-    @internalProperty() protected currentSearch: SearchRequest.ByCommune | void = undefined
+    @internalProperty() protected currentSearch: SearchRequest.ByCommune | undefined = undefined
     @property({type: String}) set searchType(type: SearchType) {
       this._searchType = type
       this.updateCurrentSearch()
@@ -734,7 +734,7 @@ export class VmdRdvParDepartementView extends AbstractVmdRdvView {
     }
     @internalProperty() private _searchType: SearchType | void = undefined
     @internalProperty() private _codeDepartement: CodeDepartement | void = undefined
-    @internalProperty() protected currentSearch: SearchRequest.ByDepartement | void = undefined
+    @internalProperty() protected currentSearch: SearchRequest.ByDepartement | undefined = undefined
 
     constructor() {
         super({

--- a/src/views/vmd-rdv.view.ts
+++ b/src/views/vmd-rdv.view.ts
@@ -322,6 +322,7 @@ export abstract class AbstractVmdRdvView extends LitElement {
                             .creneauxQuotidiens="${this.creneauxQuotidiensAffiches}"
                             @jour-selectionne="${(event: CustomEvent<RendezVousDuJour>) => {
                         this.jourSelectionne = { date: event.detail.date, type: 'manual' };
+                        Analytics.INSTANCE.clickSurJourRdv(this.jourSelectionne.date, this.jourSelectionne.type, event.detail.total);
                         this.rafraichirDonneesAffichees();
                     }}"></vmd-upcoming-days-selector>
                   </div>
@@ -472,6 +473,8 @@ export abstract class AbstractVmdRdvView extends LitElement {
                     codeDepartement,
                     this.currentTri(),
                     currentSearch.type,
+                    this.jourSelectionne?.type,
+                    this.jourSelectionne?.date,
                     commune,
                     this.lieuxParDepartementAffiches);
             } finally {


### PR DESCRIPTION
Cette Pull Request est

- [ ] Un correctif
- [X] Une nouvelle fonctionnalité

### Checklist

- Cette PR vise la branche `dev`
- Elle n'est pas en conflit avec la branche `dev`

### Description

Cette PR vient enrichir les analytics remontés suite à l'introduction des jours sélectionnables sur l'écran de prise de rdv.

2 analytics ont été impactés : 
- 1 nouvel analytics a été introduit : `appointment_day_selection` dont les metadata sont les suivantes : 
    ```
    {
            'daily_appointments' : 123, // nombre de créneaux disponibles pour le jour sélectionné
            'date_selection_type': "auto", // peut prendre les valeurs "auto" et "manual" : permet de savoir si la sélection du jour s'est faite manuellement (par un clic de l'utilisateur) ou automatiquement (auto-sélection de la première date avec des dispos)
            'selected_date': "2021-08-01", // Date au format yyyy-MM-dd qui a été sélectionnée par l'utilisateur
            'selected_date_diff': "j+4", // diff par rapport à la date du jour. Si par exemple on est le 28 juillet, et que la date sélectionnée est le 1er août, alors ont aura "j+4" ici. La valeur minimale est "j+0" (on a sélectionné le jour courant)
            'selected_weekday': "dimanche", // nom du jour de la semaine correspondant à la date sélectionnée
    }
    ```

- 2 analytics ont été enrichi : `search_by_commune` & `search_by_departement` qui contiennent dorénavant les metadata supplémentaires suivantes : `date_selection_type`, `selected_date`, `selected_date_diff` et `selected_weekday` (cf point précédent pour des détails sur ces champs)