### PR TITLE
Utilisation de notre référentiels de centres sur la page centres

### DIFF
--- a/src/views/vmd-lieux.view.ts
+++ b/src/views/vmd-lieux.view.ts
@@ -1,25 +1,26 @@
 import {css, customElement, html, LitElement, unsafeCSS} from 'lit-element';
-import {Icon, map, marker, tileLayer} from 'leaflet'
+import {Icon, LatLngTuple, map, Marker, marker, tileLayer} from 'leaflet'
 import leafletCss from 'leaflet/dist/leaflet.css';
 import leafletMarkerCss from 'leaflet.markercluster/dist/MarkerCluster.Default.css';
 // @ts-ignore
 import {MarkerClusterGroup}  from 'leaflet.markercluster'
 import {Router} from "../routing/Router";
 import {CSS_Global} from "../styles/ConstructibleStyleSheets";
+import {State} from "../state/State";
 
 // Code imported (and refactored a little bit)
 // from https://github.com/rozierguillaume/covidtracker-tools/blob/main/src/ViteMaDose/carteCentres.html
 
-type Lieu = {
+type LieuCarte = {
     nom: string;
     longitude: number;
     latitude: number;
     reservation: string;
-    date_ouverture: string;
-    rdv_tel: string;
-    modalites: string;
-    adresse: string;
-    maj: string;
+    date_ouverture: string|undefined;
+    rdv_tel: string|undefined;
+    modalites: string|undefined;
+    adresse: string|undefined;
+    maj: string|undefined;
 };
 
 @customElement('vmd-lieux')
@@ -51,132 +52,40 @@ export class VmdLieuxView extends LitElement {
         this.requestUpdate().then(() => this.loadMap());
     }
 
-    private loadMap() {
-        const mymap = map(this.shadowRoot!.querySelector("#mapid") as HTMLElement).setView([46.505, 3], 6);
-        const url="https://www.data.gouv.fr/fr/datasets/r/5cb21a85-b0b0-4a65-a249-806a040ec372"
+    private async loadMap() {
+        const mymap = map(this.shadowRoot!.querySelector("#mapid") as HTMLElement, {
 
-        fetch(url)
-            .then(response => response.arrayBuffer())
-            .then(buffer => {
-                const decoder = new TextDecoder();
-                const csv = decoder.decode(buffer);
-                const data_array = VmdLieuxView.CSVToArray(csv, ";");
+        }).setView([46.505, 3], 6);
 
-                const lieux: Lieu[] = data_array.slice(1, data_array.length-1).map((value: string[]) => ({
-                    longitude: Number(value[10]),
-                    latitude: Number(value[11]),
-                    nom: value[1],
-                    reservation: (!value[34])?"":value[34].replace("partners.doctolib.fr", "www.doctolib.fr"),
-                    date_ouverture: value[33],
-                    rdv_tel: value[35],
-                    modalites: value[37],
-                    adresse: value[5] + " " + value[6] + ", " + value[7] + " " + value[9],
-                    maj: value[22].slice(0, 16),
-                }))
-
-                const markers = VmdLieuxView.creer_pins(lieux);
-                mymap.addLayer(markers);
-            })
-            .catch(function () {
-                // this.dataError = true;
-                console.log("error1")
-            });
+        const departements = await State.current.departementsDisponibles();
+        const resultatsRechercheLieux = await State.current.lieuxPour(departements.map(d => d.code_departement).filter(code => code !== 'om'));
+        const lieuxCarte = resultatsRechercheLieux.lieuxDisponibles.concat(resultatsRechercheLieux.lieuxIndisponibles)
+            .filter(lieu => !!lieu.location && !!lieu.location.longitude && lieu.location.latitude)
+            // We have some location which have silly locations, like longitude=6786471059425410 (missing comma)
+            .filter(lieu => lieu.location.latitude >= -90 && lieu.location.latitude <= 90 && lieu.location.longitude >= -180 && lieu.location.longitude <= 180)
+            .map<LieuCarte>(lieu => ({
+                nom: lieu.nom,
+                longitude: lieu.location.longitude,
+                latitude: lieu.location.latitude,
+                reservation: lieu.url,
+                date_ouverture: undefined,
+                rdv_tel: lieu?.metadata?.phone_number,
+                modalites: undefined,
+                adresse: lieu?.metadata?.address,
+                maj: undefined,
+            }));
 
         tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
             maxZoom: 19,
             attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         }).addTo(mymap);
+
+        const markers = VmdLieuxView.creer_pins(lieuxCarte);
+        mymap.addLayer(markers);
     }
 
-    // ref: http://stackoverflow.com/a/1293163/2343
-    // This will parse a delimited string into an array of
-    // arrays. The default delimiter is the comma, but this
-    // can be overriden in the second argument.
-    private static CSVToArray(strData: string, strDelimiter: string ): string[][]{
-        // Check to see if the delimiter is defined. If not,
-        // then default to comma.
-        strDelimiter = (strDelimiter || ",");
-
-        // Create a regular expression to parse the CSV values.
-        let objPattern = new RegExp(
-            (
-                // Delimiters.
-                "(\\" + strDelimiter + "|\\r?\\n|\\r|^)" +
-
-                // Quoted fields.
-                "(?:\"([^\"]*(?:\"\"[^\"]*)*)\"|" +
-
-                // Standard fields.
-                "([^\"\\" + strDelimiter + "\\r\\n]*))"
-            ),
-            "gi"
-        );
-
-
-        // Create an array to hold our data. Give the array
-        // a default empty first row.
-        let arrData = [[]] as string[][];
-
-        // Create an array to hold our individual pattern
-        // matching groups.
-        let arrMatches = null;
-
-
-        // Keep looping over the regular expression matches
-        // until we can no longer find a match.
-        while (arrMatches = objPattern.exec( strData )){
-
-            // Get the delimiter that was found.
-            let strMatchedDelimiter = arrMatches[ 1 ];
-
-            // Check to see if the given delimiter has a length
-            // (is not the start of string) and if it matches
-            // field delimiter. If id does not, then we know
-            // that this delimiter is a row delimiter.
-            if (
-                strMatchedDelimiter.length &&
-                strMatchedDelimiter !== strDelimiter
-            ){
-
-                // Since we have reached a new row of data,
-                // add an empty row to our data array.
-                arrData.push( [] );
-
-            }
-
-            let strMatchedValue;
-
-            // Now that we have our delimiter out of the way,
-            // let's check to see which kind of value we
-            // captured (quoted or unquoted).
-            if (arrMatches[ 2 ]){
-
-                // We found a quoted value. When we capture
-                // this value, unescape any double quotes.
-                strMatchedValue = arrMatches[ 2 ].replace(
-                    new RegExp( "\"\"", "g" ),
-                    "\""
-                );
-
-            } else {
-
-                // We found a non-quoted value.
-                strMatchedValue = arrMatches[ 3 ];
-
-            }
-
-
-            // Now that we have our value string, let's add
-            // it to the data array.
-            arrData[ arrData.length - 1 ].push( strMatchedValue );
-        }
-
-        // Return the parsed data.
-        return arrData;
-    }
-
-    private static creer_pins(lieux: Lieu[]){
-        const markers = lieux.reduce((markers: MarkerClusterGroup, lieu) => {
+    private static creer_pins(lieux: LieuCarte[]){
+        const markers = lieux.reduce((markers, lieu) => {
             let reservation_str = ""
             if (typeof lieu.reservation != 'undefined'){
                 if (lieu.reservation.indexOf("http") === 0){
@@ -192,23 +101,24 @@ export class VmdLieuxView extends LitElement {
                 <b>Adresse :</b> ${lieu.adresse}<br><b>Réservation :</b> ${reservation_str}
                 <br>
                 <b>Tél :</b> <a href:'tel:${lieu.rdv_tel}'>${lieu.rdv_tel}</a>
-                <br>
-                <b>Date d'ouverture :</b> ${lieu.date_ouverture}<br><b>Modalités :</b> ${lieu.modalites}
-                <br>
-                <b>Mise à jour :</b> ${lieu.maj}
             `;
-            const newMarker = marker([lieu.longitude, lieu.latitude], {
+            const newMarker = marker([lieu.latitude, lieu.longitude] as LatLngTuple, {
                 icon: new Icon.Default({imagePath: `${Router.basePath}assets/images/png/`})
             }).bindPopup(string_popup) //.addTo(this.mymap);
             newMarker.on('click', function() {
                 // @ts-ignore
                 this.openPopup();
             });
-            markers.addLayer(newMarker);
 
+            markers.push(newMarker);
             return markers;
-        }, new MarkerClusterGroup({ disableClusteringAtZoom: 9 }));
-        return markers;
+        }, [] as Marker[]);
+
+        const markersGroup = new MarkerClusterGroup({
+            disableClusteringAtZoom: 9, chunkedLoading: true,
+        })
+        markersGroup.addLayers(markers, true);
+        return markersGroup;
     }
 
     disconnectedCallback() {


### PR DESCRIPTION
Cette Pull Request est

- Un correctif

### Checklist

- Si cette PR résout une [issue](https://github.com/CovidTrackerFr/vitemadose-front/issues), j'indique son numéro dans les description
- Cette PR vise la branche `dev`
- Elle n'est pas en conflit avec la branche `dev`

### Description

Actuellement, sur la page centres (https://vitemadose.covidtracker.fr/centres) on se base sur la liste des 2900 centres fournis par data.gouv.fr ici : https://www.data.gouv.fr/fr/datasets/r/5cb21a85-b0b0-4a65-a249-806a040ec372

Lorsqu'on récupère la liste de tous les centres dispos/indispos de tous les départements via l'API VMD, on monte à 5838 centres.

C'est ce que je propose de faire sur cette PR, les résultats étant visibles ici : https://dev.vitemado.se/centres-issus-de-vmd-sur-page-centre/

PS: pour faire fonctionner tout ça, j'ai dû exclure un centre qui avait une longitude un peu chelou (manquait la virgule...) : 
![image](https://user-images.githubusercontent.com/603815/144710168-7883d4c9-bae0-47d0-b114-c96e6fbd2e17.png)
car il faisait partir complètement en vrille le CPU lors du processing par leaflet
_j'ai remonté à Doctolib l'erreur car elle vient de chez eux à priori ([la fiche docto](https://doctolib.fr/medecin-generaliste/abondance/elodie-fesson-lorin) n'arrive pas à afficher le lieu du centre sur la carte)_