### PR TITLE
#272 fix ios search bar

### DIFF
--- a/src/components/vmd-commune-or-departement-selector.component.scss
+++ b/src/components/vmd-commune-or-departement-selector.component.scss
@@ -90,6 +90,7 @@ label,
         -webkit-appearance: none;
         appearance: none;
         outline: none;
+        background-color: -webkit-control-background;
 
         &:focus {
             box-shadow: 0 0 0 $form-select-focus-width $input-btn-focus-color;


### PR DESCRIPTION
Cette Pull Request est

- Un correctif

### Checklist

- fix l'issue #272 

### Description

> Correction de la couleur d'affichage de la searchbar sur IOS. 

```css
background-color: -webkit-control-background;
``` 

> Les modifications ont été testé sur un simulateur IOS sur un Mac.

<img width="383" alt="Capture d’écran 2021-12-30 à 13 34 39" src="https://user-images.githubusercontent.com/52243730/147752395-9e97b8bb-6fe5-4097-a8f4-56bf1ca6a1c7.png">

> Il a été également vérifié qu'il n'y avait pas d'effet de bord sur les navigateurs suivants : Safari, Chrome, Edge, Firefox