### PR TITLE
#271 fix ios calendar line

### DIFF
--- a/src/components/vmd-upcoming-days-selector.component.scss
+++ b/src/components/vmd-upcoming-days-selector.component.scss
@@ -18,9 +18,9 @@
     top: 0;
     height: 100%;
     width: calc(var(--day-gutter) * 2);
-    height: calc(100% - var(--day-gutter));
     background: $light;
-    background: linear-gradient(90deg, rgba($light, 255) 20%, rgba(255,255,255, 0) 100%);
+    background: linear-gradient(90deg, rgba($light, 255) 20%, rgba(255, 255, 255, 0) 100%);
+    background-repeat: no-repeat;
   }
 
   &::before {


### PR DESCRIPTION
Cette Pull Request est

- Un correctif

### Checklist

- fix l'issue #271 

### Description

> Correction de l'affichage du calendrier, suppression de la ligne verticale présente sur IOS.

```css
background-repeat: no-repeat;
```

<img width="320" alt="Capture d’écran 2021-12-30 à 14 29 41" src="https://user-images.githubusercontent.com/52243730/147756302-7978b03b-721e-4fac-82ad-ea7744d899bc.png">

> Correction de la taille de la goutière pour correspondre à une ligne entière (même lorsqu'un élément est sélectionné).

```css
height: 100%;
```

> Avant correction 

![](https://user-images.githubusercontent.com/603815/144032799-be996637-111b-48ef-b3d5-84b729d258a5.png)

> Après correction 

<img width="399" alt="Capture d’écran 2021-12-30 à 15 02 20" src="https://user-images.githubusercontent.com/52243730/147758670-ff66c09c-d086-49e0-918c-e0edb318248f.png">


> Il a été également vérifié qu'il n'y avait pas d'effet de bord sur les navigateurs suivants : Safari, Chrome, Edge, Firefox.


