### PR TITLE
removed google tag manager + disabled analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,9 +42,6 @@
 
     <script type="module" src="/src/index.ts"></script>
 
-    <!-- Google Tag Manager tag (gtm.js) - Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-KWWTRTX');</script>
-
     <!-- Google rich results card -->
     <script type="application/ld+json">
         {
@@ -63,7 +60,6 @@
     </script>
 </head>
 <body>
-    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KWWTRTX" height="0" width="0" style="display:none;visibility:hidden"></iframe>
     <div class="container-xxl">
         <vmd-app>
             <h1 slot="main-title">

--- a/src/utils/Analytics.ts
+++ b/src/utils/Analytics.ts
@@ -20,44 +20,51 @@ declare global {
 
 export class Analytics {
     public static readonly INSTANCE = new Analytics();
+    private readonly analyticsEnabled = false;
 
     protected constructor() {
     }
 
     navigationSurNouvellePage(nomPage: string) {
-        window.dataLayer.push({
-            'event': 'change_screen',
-            'site_name' : 'vite_ma_dose',
-            'page_type' : nomPage
-        });
+        if(this.analyticsEnabled) {
+            window.dataLayer.push({
+                'event': 'change_screen',
+                'site_name' : 'vite_ma_dose',
+                'page_type' : nomPage
+            });
+        }
     }
 
     clickSurRdv(lieu: Lieu, triCentre: CodeTriCentre|'unknown', searchType: SearchType, commune: Commune|undefined) {
-        window.dataLayer.push({
-            'event': 'rdv_click',
-            'rdv_departement' : lieu.departement,
-            'rdv_commune' : commune?`${commune.codePostal} - ${commune.nom} (${commune.code})`:undefined,
-            'rdv_platform' : lieu.plateforme,
-            'rdv_name': lieu.nom,
-            'rdv_location_type' : lieu.type,
-            'rdv_vaccine' : lieu.vaccine_type,
-            'rdv_sort_type' : triCentre,
-            'rdv_filter_type' : [`kind:${searchType}`].join("|")
-        });
+        if(this.analyticsEnabled) {
+            window.dataLayer.push({
+                'event': 'rdv_click',
+                'rdv_departement': lieu.departement,
+                'rdv_commune': commune ? `${commune.codePostal} - ${commune.nom} (${commune.code})` : undefined,
+                'rdv_platform': lieu.plateforme,
+                'rdv_name': lieu.nom,
+                'rdv_location_type': lieu.type,
+                'rdv_vaccine': lieu.vaccine_type,
+                'rdv_sort_type': triCentre,
+                'rdv_filter_type': [`kind:${searchType}`].join("|")
+            });
+        }
     }
 
     clickSurVerifRdv(lieu: Lieu, triCentre: CodeTriCentre|'unknown', searchType: SearchType, commune: Commune|undefined) {
-        window.dataLayer.push({
-            'event': 'rdv_verify',
-            'rdv_departement' : lieu.departement,
-            'rdv_commune' : commune?`${commune.codePostal} - ${commune.nom} (${commune.code})`:undefined,
-            'rdv_platform' : lieu.plateforme,
-            'rdv_name': lieu.nom,
-            'rdv_location_type' : lieu.type,
-            'rdv_vaccine' : lieu.vaccine_type,
-            'rdv_sort_type' : triCentre,
-            'rdv_filter_type' : [`kind:${searchType}`].join("|")
-        });
+        if(this.analyticsEnabled) {
+            window.dataLayer.push({
+                'event': 'rdv_verify',
+                'rdv_departement': lieu.departement,
+                'rdv_commune': commune ? `${commune.codePostal} - ${commune.nom} (${commune.code})` : undefined,
+                'rdv_platform': lieu.plateforme,
+                'rdv_name': lieu.nom,
+                'rdv_location_type': lieu.type,
+                'rdv_vaccine': lieu.vaccine_type,
+                'rdv_sort_type': triCentre,
+                'rdv_filter_type': [`kind:${searchType}`].join("|")
+            });
+        }
     }
 
     static analyticsForJourSelectionne(jourSelectionne: string|undefined) {
@@ -68,44 +75,50 @@ export class Analytics {
     }
 
     clickSurJourRdv(jourSelectionne: string | undefined, typeSelectionDate: "auto" | "manual" | undefined, total: number) {
-        const jourSelectionneAnalytics = Analytics.analyticsForJourSelectionne(jourSelectionne);
-        window.dataLayer.push({
-            'event': 'appointment_day_selection',
-            'daily_appointments' : total,
-            'date_selection_type': typeSelectionDate,
-            'selected_date': jourSelectionne,
-            'selected_date_diff': jourSelectionneAnalytics.diffDays,
-            'selected_weekday': jourSelectionneAnalytics.weekday,
-        });
+        if(this.analyticsEnabled) {
+            const jourSelectionneAnalytics = Analytics.analyticsForJourSelectionne(jourSelectionne);
+            window.dataLayer.push({
+                'event': 'appointment_day_selection',
+                'daily_appointments': total,
+                'date_selection_type': typeSelectionDate,
+                'selected_date': jourSelectionne,
+                'selected_date_diff': jourSelectionneAnalytics.diffDays,
+                'selected_weekday': jourSelectionneAnalytics.weekday,
+            });
+        }
     }
 
     rechercheLieuEffectuee(codeDepartement: CodeDepartement, triCentre: CodeTriCentre|'unknown', searchType: SearchType, typeSelectionDate: 'auto'|'manual'|undefined, jourSelectionne: string|undefined, commune: Commune|undefined, resultats: LieuxAvecDistanceParDepartement|undefined) {
-        const jourSelectionneAnalytics = Analytics.analyticsForJourSelectionne(jourSelectionne);
-        window.dataLayer.push({
-            'event': commune?'search_by_commune':'search_by_departement',
-            'search_departement': codeDepartement,
-            'search_commune' : commune?`${commune.codePostal} - ${commune.nom} (${commune.code})`:undefined,
-            'search_nb_appointments' : resultats?resultats.lieuxDisponibles.reduce((totalDoses, lieu) => totalDoses+lieu.appointment_count, 0):undefined,
-            'search_nb_lieu_vaccination' : resultats?resultats.lieuxDisponibles
-                .filter(isLieuActif)
-                .length:undefined,
-            'search_nb_lieu_vaccination_inactive' : resultats?resultats.lieuxDisponibles
-                .filter(l => !isLieuActif(l))
-                .length:undefined,
-            'search_sort_type': triCentre,
-            'search_filter_type' : [`kind:${searchType}`].join("|"),
-            'date_selection_type': typeSelectionDate,
-            'selected_date': jourSelectionne,
-            'selected_date_diff': jourSelectionneAnalytics.diffDays,
-            'selected_weekday': jourSelectionneAnalytics.weekday,
-        });
+        if(this.analyticsEnabled) {
+            const jourSelectionneAnalytics = Analytics.analyticsForJourSelectionne(jourSelectionne);
+            window.dataLayer.push({
+                'event': commune ? 'search_by_commune' : 'search_by_departement',
+                'search_departement': codeDepartement,
+                'search_commune': commune ? `${commune.codePostal} - ${commune.nom} (${commune.code})` : undefined,
+                'search_nb_appointments': resultats ? resultats.lieuxDisponibles.reduce((totalDoses, lieu) => totalDoses + lieu.appointment_count, 0) : undefined,
+                'search_nb_lieu_vaccination': resultats ? resultats.lieuxDisponibles
+                    .filter(isLieuActif)
+                    .length : undefined,
+                'search_nb_lieu_vaccination_inactive': resultats ? resultats.lieuxDisponibles
+                    .filter(l => !isLieuActif(l))
+                    .length : undefined,
+                'search_sort_type': triCentre,
+                'search_filter_type': [`kind:${searchType}`].join("|"),
+                'date_selection_type': typeSelectionDate,
+                'selected_date': jourSelectionne,
+                'selected_date_diff': jourSelectionneAnalytics.diffDays,
+                'selected_weekday': jourSelectionneAnalytics.weekday,
+            });
+        }
     }
 
     critereTriCentresMisAJour(triCentre: CodeTriCentre) {
-        window.dataLayer.push({
-            'event': 'sort_change',
-            'sort_changed_to' : triCentre,
-        });
+        if(this.analyticsEnabled) {
+            window.dataLayer.push({
+                'event': 'sort_change',
+                'sort_changed_to': triCentre,
+            });
+        }
     }
 
 }


### PR DESCRIPTION
Cette Pull Request est

- Un correctif

### Checklist

- Cette PR vise la branche `dev`
- Elle n'est pas en conflit avec la branche `dev`

### Description

Suite à décision rendue [en février par la CNIL](https://www.cnil.fr/fr/utilisation-de-google-analytics-et-transferts-de-donnees-vers-les-etats-unis-la-cnil-met-en-demeure), j'ai supprimé les usages à Google Tag Manager / les Analytics sur VMD, afin de supprimer tout cookie google déposé sur le device de l'utilisateur.

⚠️  Ça signifie qu'une fois déployé en prod, nous n'aurons plus aucun analytics sur les usages de VMD par nos utilisateurs, et donc ne plus connaître les statistiques d'usages de telle ou telle fonctionnalité / département / code postal.

Pour tester : https://dev.vitemado.se/goodbye-gtm/