### PR TITLE
removed first shot option on result screens

### DIFF
--- a/src/views/vmd-rdv.view.ts
+++ b/src/views/vmd-rdv.view.ts
@@ -289,7 +289,7 @@ export abstract class AbstractVmdRdvView extends LitElement {
                     <div class="col">
                         <vmd-button-switch class="mb-3" style="display: inline-block"
                                            codeSelectionne="${this.currentSearch?.type || 'dose_rappel'}"
-                                           .options="${[{code: 'dose_rappel', libelle: 'Une dose de rappel'}, {code: 'dose_1_enfants', libelle: 'Une dose pour 5-11 ans'}, {code: 'dose_1_ou_2', libelle: 'Une 1ère dose de vaccin'}]}"
+                                           .options="${[{code: 'dose_rappel', libelle: 'Une dose pour 12 ans et plus'}, {code: 'dose_1_enfants', libelle: 'Une dose pour 5-11 ans'} /*, {code: 'dose_1_ou_2', libelle: 'Une 1ère dose de vaccin'} */]}"
                                            @changed="${(e: CustomEvent<{value: SearchType}>) => this.updateSearchTypeTo(e.detail.value)}">
                         </vmd-button-switch>
                     </div>


### PR DESCRIPTION
Cette Pull Request est

- Un correctif

### Checklist

- Cette PR vise la branche `dev`
- Elle n'est pas en conflit avec la branche `dev`

### Description

Plus d'un an et demi après l'apparition du vaccin, l'argument visant à faciliter les prises de rdv pour les 1ères doses n'a plus lieu d'être
=> Je propose de supprimer l'option "Une 1ère dose de vaccin" de l'UI car ce choix n'est plus vraiment intéressant.

De ce fait, le choix par défaut "Une dose de rappel" est modifié en "Une dose pour 12 ans et plus", en complément au choix "Une dose pour 5-11 ans"

<img width="1403" alt="Vaccination_COVID-19_à_Villenave-d_Ornon_33140" src="https://user-images.githubusercontent.com/603815/198147048-f5a034ba-ed96-4b73-9cd6-3dc841c15f1c.png">


Pour tester : https://dev.vitemado.se/goodbye-first-shot/